### PR TITLE
DBをMySQLからPostgreSQLに変更

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,12 +6,14 @@ ENV TZ Asia/Tokyo
 ENV RAILS_ENV=development
 
 # 必要なシステムライブラリをインストール
-# default-mysql-client: RailsからMySQLに接続するために必要
-RUN apt-get update -qq && apt-get install -y \
+# postgresql-client: RailsからPostgreSQLに接続するために必要
+RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+  build-essential \
+  libpq-dev \
+  postgresql-client \
   ca-certificates \
   curl \
   gnupg \
-  default-mysql-client \
   vim \
   nano \
   && rm -rf /var/lib/apt/lists/*

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,8 @@ gem "rails", "~> 7.1.5", ">= 7.1.5.2"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 
-# Use mysql as the database for Active Record
-gem "mysql2", "~> 0.5"
+# Use postgres as the database for Active Record
+gem "pg", "~> 1.1"
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,6 @@ GEM
     minitest (5.25.5)
     msgpack (1.8.0)
     mutex_m (0.3.0)
-    mysql2 (0.5.6)
     net-imap (0.5.9)
       date
       net-protocol
@@ -152,6 +151,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
+    pg (1.6.2-aarch64-linux)
+    pg (1.6.2-x86_64-linux)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -257,7 +258,7 @@ DEPENDENCIES
   debug
   importmap-rails
   jbuilder
-  mysql2 (~> 0.5)
+  pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.5, >= 7.1.5.2)
   selenium-webdriver

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@
 
 - **MVP（Railsのみ/アバターなし）**  
   - `Ruby on Rails`: 7.1.5
-  - `MySQL`: データベース
+  - `PostgreSQL 16`: データベース
   - `Heroku`: デプロイサーバー
   - `devise`: 認証機能
   - `chartkick`+`groupdate`: 週次/種目別グラフの表示  

--- a/compose.yml
+++ b/compose.yml
@@ -1,16 +1,14 @@
 services:
   db:
-    image: mysql:8.0
+    image: postgres:16
     environment:
-      MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: myapp_development
-      MYSQL_USER: rails
-      MYSQL_PASSWORD: password
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: my_training_log_development
     ports:
-      - "3306:3306"
+      - "5432:5432"
     volumes:
-      - mysql_data:/var/lib/mysql
-    command: --default-authentication-plugin=mysql_native_password
+      - postgres_data:/var/lib/postgresql/data
 
   app:
     build:
@@ -25,12 +23,12 @@ services:
       - db
     environment:
       DATABASE_HOST: db
-      DATABASE_USERNAME: rails
+      DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: password
-      DATABASE_NAME: myapp_development
+      DATABASE_NAME: my_training_log_development
     stdin_open: true
     tty: true
 
 volumes:
-  mysql_data:
+  postgres_data:
   bundle_cache:

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,15 +1,15 @@
 default: &default
-  adapter: mysql2
-  encoding: utf8mb4
+  adapter: postgresql
+  encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: <%= ENV.fetch("DATABASE_USERNAME", "rails") %>
-  password: <%= ENV.fetch("DATABASE_PASSWORD", "password") %>
-  host: <%= ENV.fetch("DATABASE_HOST", "db") %>
+  username: <%= ENV.fetch("DATABASE_USERNAME") { "postgres" } %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD") { "password" } %>
+  host: <%= ENV.fetch("DATABASE_HOST") { "localhost" } %>
 
 development:
   <<: *default
-  database: myapp_development
+  database: <%= ENV.fetch("DATABASE_NAME") { "my_training_log_development" } %>
 
 test:
   <<: *default
-  database: myapp_test
+  database: my_training_log_test


### PR DESCRIPTION
close #40 

## 📝 変更内容
データベースをMySQLからPostgreSQLに移行しました。

## 🎯 目的・背景
- 本番環境でPostgreSQLを使用予定のため、開発環境も統一
- PostgreSQLの豊富な機能を活用するため
- Herokuなどのクラウドサービスでの運用を想定

## 🔧 主な変更点

### 1. データベース設定の変更
- **config/database.yml**: MySQL設定 → PostgreSQL設定に変更
- **compose.yml**: MySQL設定→ PostgreSQL設定に変更
- **接続情報**: ホスト、ポート、認証情報をPostgreSQL用に更新

### 2. Gemfile の更新
- **削除**: `mysql2` gem
- **追加**: `pg` gem (PostgreSQL adapter)

### 3. Docker設定の更新
- **Dockerfile.dev**: 
  - `mysql-client` → `postgresql-client` に変更
  - `libpq-dev` を追加（pg gem のネイティブ拡張用）
  - `build-essential` を追加（コンパイル環境）

### 4. ドキュメントの更新
- **README.md**: 
  - 技術スタック情報の更新

## ✅ 動作確認

### 環境構築の確認
```bash
# Docker build: 成功
[+] Building 1/1 ✔ my_training_log-app Built

# bundle install: 成功  
Bundle complete! 14 Gemfile dependencies, 86 gems now installed.

# pg gem 読み込み確認: 成功
pg gem loaded successfully