### PR TITLE
Gem導入時に記載を行ってなかったRSpecに関しての設定の追加

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,3 @@
 --require spec_helper
+
+--format documentation

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,6 +45,8 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
 
+  config.full_backtrace = false
+
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 


### PR DESCRIPTION
close #13 

## 概要
RSpecに関しての追記

## 変更内容
- `.rspec` に `--format documentaiton` の追記

## 確認手順
1. `docker compose exec app bundle exec rspec` でRSpecが実行できることを確認

## 補足
-  今後実際にモデルやコントローラーを作成したタイミングで、必要なファクトリ（spec/factories/users.rb など）を作る。テスト対象の機能が増えるにつれてファクトリやテストデータを追加・調整していく。