### PR TITLE
Exerciseモデルの生成とExercisesテーブルの作成

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,0 +1,12 @@
+class Exercise < ApplicationRecord
+    belongs_to :body_part
+    belongs_to :user, optional: true
+
+    validates :name, length: { maximum: 50 }
+    validates :name, presence: true
+    validates :name, uniqueness: { scope: :user_id }
+
+    def default_exercise?
+        is_default && user_id.nil?
+    end
+end

--- a/db/migrate/20250929125244_create_exercises.rb
+++ b/db/migrate/20250929125244_create_exercises.rb
@@ -1,0 +1,16 @@
+class CreateExercises < ActiveRecord::Migration[7.1]
+  def change
+    create_table :exercises do |t|
+      t.string :name, null: false, limit: 50
+      t.boolean :is_default, null: false, default: false
+
+      t.references :user, null: true, foreign_key: true
+      t.references :body_part, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :exercises, [:user_id, :name], unique: true
+    add_index :exercises, :name, unique: true, where: "user_id IS NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_28_112525) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_29_125244) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,19 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_28_112525) do
     t.integer "display_order"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "exercises", force: :cascade do |t|
+    t.string "name", limit: 50, null: false
+    t.boolean "is_default", default: false, null: false
+    t.bigint "user_id"
+    t.bigint "body_part_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["body_part_id"], name: "index_exercises_on_body_part_id"
+    t.index ["name"], name: "index_exercises_on_name", unique: true, where: "(user_id IS NULL)"
+    t.index ["user_id", "name"], name: "index_exercises_on_user_id_and_name", unique: true
+    t.index ["user_id"], name: "index_exercises_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -36,4 +49,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_28_112525) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "exercises", "body_parts"
+  add_foreign_key "exercises", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
+# BodyParts マスタデータ
 body_parts = [
   { name: '胸', display_order: 1 },
   { name: '背中', display_order: 2 },
@@ -11,4 +12,26 @@ body_parts.each do |bp|
     BodyPart.find_or_create_by!(name: bp[:name]) do |part|
         part.display_order = bp[:display_order]
     end
+end
+
+# Exercises マスタデータ
+exercises = {
+  '胸' => ['ベンチプレス', 'インクラインベンチプレス', 'ダンベルフライ'],
+  '背中' => ['デッドリフト', 'ラットプルダウン', 'ベントオーバーロー'],
+  '脚' => ['スクワット', 'レッグプレス', 'ランジ'],
+  '肩' => ['ショルダープレス', 'サイドレイズ'],
+  '腕' => ['アームカール', 'トライセプスエクステンション'],
+  '腹' => ['クランチ', 'レッグレイズ']
+}
+
+exercises.each do |body_part_name, names|
+  body_part = BodyPart.find_by!(name: body_part_name)
+  names.each do |exercise_name|
+    Exercise.find_or_create_by!(
+      name: exercise_name,
+      body_part: body_part,
+      is_default: true,
+      user_id: nil
+    )
+  end
 end

--- a/spec/factories/exercises.rb
+++ b/spec/factories/exercises.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :exercise do
+    name { "MyString" }
+    is_default { false }
+  end
+end

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Exercise, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
Exerciseモデルの生成とexercisesテーブルの作成を行いました。  
また、seedファイルに公式種目（マスタデータ）を各部位ごとに投入しました。
## 実装内容
<!-- 実装した内容を箇条書きで記載 -->
- Exerciseモデルの作成
  - `name` (string, limit: 50, null: false)
  - `is_default` (boolean, null: false, default: false)
  - `user_id` (references, null: true, 外部キー制約)
  - `body_part_id` (references, null: false, 外部キー制約)
- バリデーション
  - `name`: presence, uniqueness（user_idとのスコープ）
  - 文字数制限（最大50文字）
- メソッド追加
  - `default_exercise?` で公式種目かどうか判定
- マイグレーション
  - 複合インデックス `[:user_id, :name]` を追加（ユーザーごとに重複禁止）
  - 部分インデックス（`user_id IS NULL` の場合、nameユニーク）を追加
- seeds.rb の更新
  - BodyPartごとの公式種目を追加（胸、背中、脚、肩、腕、腹）
  - `find_or_create_by!` を使用し、重複登録を防止
## 動作確認
<!-- 確認した動作や手順を記載 -->
- `docker compose exec app rails db:migrate` を実行し、exercisesテーブルが作成されることを確認
- `docker compose exec app rails db:seed` を実行し、公式種目が登録されることを確認
- `rails c` で以下を確認
  ```ruby
  Exercise.where(is_default: true).pluck(:name)
  # => ["ベンチプレス", "インクラインベンチプレス", "ダンベルフライ", "デッドリフト", "ラットプルダウン", "ベントオーバーロー", "スクワット", "レッグプレス", "ランジ", "ショルダープレス", "サイドレイズ", "アームカール", "トライセプスエクステンション", "クランチ", "レッグレイズ"]