### PR TITLE
BodyPartsテーブルに制約を追加及びモデルの修正

### DIFF
--- a/app/models/body_part.rb
+++ b/app/models/body_part.rb
@@ -1,4 +1,6 @@
 class BodyPart < ApplicationRecord
     validates :name, presence: true, uniqueness: true
     validates :display_order, presence: true, uniqueness: true
+
+    default_scope { order(:display_order) }
 end

--- a/db/migrate/20251002111304_update_body_parts_constraints.rb
+++ b/db/migrate/20251002111304_update_body_parts_constraints.rb
@@ -1,0 +1,9 @@
+class UpdateBodyPartsConstraints < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :body_parts, :name, false
+    change_column_null :body_parts, :display_order, false
+
+    add_index :body_parts, :name, unique: true
+    add_index :body_parts, :display_order, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_29_125244) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_02_111304) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "body_parts", force: :cascade do |t|
-    t.string "name"
-    t.integer "display_order"
+    t.string "name", null: false
+    t.integer "display_order", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["display_order"], name: "index_body_parts_on_display_order", unique: true
+    t.index ["name"], name: "index_body_parts_on_name", unique: true
   end
 
   create_table "exercises", force: :cascade do |t|


### PR DESCRIPTION
close #48 

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
BodyPartsテーブルに制約を追加し、モデルを修正しました。  
これにより、マスタデータとしての一貫性を保ちつつ、常に安定した順序でデータを取得できるようにしました。
## 実装内容
<!-- 実装した内容を箇条書きで記載 -->
- migrationの追加
  - `name` カラムに `null: false` 制約を追加
  - `display_order` カラムに `null: false` 制約を追加
  - `name` にユニークインデックスを追加
  - `display_order` にユニークインデックスを追加
- モデル修正（`app/models/body_part.rb`）
   - 並び順を固定するためのスコープを追加  
    ```ruby
    default_scope { order(:display_order) }
    ```
## 動作確認
<!-- 確認した動作や手順を記載 -->
- `docker compose exec app rails db:migrate` がエラーなく実行できることを確認
- `db/schema.rb` にインデックスと `null: false` 制約が反映されていることを確認
- Railsコンソールで以下を確認  
  ```ruby
  BodyPart.create(name: nil, display_order: 7) # => エラーになる
  BodyPart.create(name: "胸", display_order: nil) # => エラーになる
  BodyPart.create(name: "胸", display_order: 1)   # => 重複してエラーになる
  BodyPart.all.pluck(:name)
  # => ["胸", "背中", "脚", "肩", "腕", "腹"] （display_order順で並ぶ）
