### PR TITLE
Workoutモデル・WorkoutSetモデルの作成とマイグレーションの実装

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :workouts, dependent: :destroy
 
   enum gender: { male: 1, female: 2 }
   # Include default devise modules. Others available are:

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -1,0 +1,3 @@
+class Workout < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -1,6 +1,6 @@
 class Workout < ApplicationRecord
   belongs_to :user
-  has_many :workout_sets, dependent: :destory
+  has_many :workout_sets, dependent: :destroy
 
   validates :workout_date, presence: true
   validates :notes, length: { maximum: 500 }, allow_blank: true

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -1,3 +1,7 @@
 class Workout < ApplicationRecord
   belongs_to :user
+  has_many :workout_sets, dependent: :destory
+
+  validates :workout_date, presence: true
+  validates :notes, length: { maximum: 500 }, allow_blank: true
 end

--- a/app/models/workout_set.rb
+++ b/app/models/workout_set.rb
@@ -1,0 +1,4 @@
+class WorkoutSet < ApplicationRecord
+  belongs_to :workout
+  belongs_to :exercise
+end

--- a/app/models/workout_set.rb
+++ b/app/models/workout_set.rb
@@ -1,4 +1,16 @@
 class WorkoutSet < ApplicationRecord
   belongs_to :workout
   belongs_to :exercise
+
+  validates :set_number, presence: true, numericality: { greater_than: 0 }
+
+  validate :at_least_one_value_present
+
+  private
+
+  def at_least_one_value_present
+    if weight.blank? && reps.blank? && memo.blank?
+      errors.add(:base, "重量、回数、メモのいずれかを入力してください")
+    end
+  end
 end

--- a/db/migrate/20251002125149_create_workouts.rb
+++ b/db/migrate/20251002125149_create_workouts.rb
@@ -1,0 +1,13 @@
+class CreateWorkouts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :workouts do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :workout_date, null: false
+      t.text :notes
+
+      t.timestamps
+    end
+
+    add_index :workouts, [:user_id, :workout_date]
+  end
+end

--- a/db/migrate/20251002125505_create_workout_sets.rb
+++ b/db/migrate/20251002125505_create_workout_sets.rb
@@ -1,0 +1,16 @@
+class CreateWorkoutSets < ActiveRecord::Migration[7.1]
+  def change
+    create_table :workout_sets do |t|
+      t.references :workout, null: false, foreign_key: true
+      t.references :exercise, null: false, foreign_key: true
+      t.integer :set_number, null: false
+      t.decimal :weight, precision: 5, scale: 2, null: true
+      t.integer :reps, null: true
+      t.text :memo, null: true
+
+      t.timestamps
+    end
+
+    add_index :workout_sets, [:workout_id, :exercise_id, :set_number], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_10_02_111304) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_02_125505) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,33 @@ ActiveRecord::Schema[7.1].define(version: 2025_10_02_111304) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "workout_sets", force: :cascade do |t|
+    t.bigint "workout_id", null: false
+    t.bigint "exercise_id", null: false
+    t.integer "set_number", null: false
+    t.decimal "weight", precision: 5, scale: 2
+    t.integer "reps"
+    t.text "memo"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["exercise_id"], name: "index_workout_sets_on_exercise_id"
+    t.index ["workout_id", "exercise_id", "set_number"], name: "idx_on_workout_id_exercise_id_set_number_db8390fc60", unique: true
+    t.index ["workout_id"], name: "index_workout_sets_on_workout_id"
+  end
+
+  create_table "workouts", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "workout_date", null: false
+    t.text "notes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "workout_date"], name: "index_workouts_on_user_id_and_workout_date"
+    t.index ["user_id"], name: "index_workouts_on_user_id"
+  end
+
   add_foreign_key "exercises", "body_parts"
   add_foreign_key "exercises", "users"
+  add_foreign_key "workout_sets", "exercises"
+  add_foreign_key "workout_sets", "workouts"
+  add_foreign_key "workouts", "users"
 end

--- a/spec/factories/workout_sets.rb
+++ b/spec/factories/workout_sets.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :workout_set do
+    workout { nil }
+    exercise { nil }
+    set_number { 1 }
+    weight { "9.99" }
+    reps { 1 }
+  end
+end

--- a/spec/factories/workouts.rb
+++ b/spec/factories/workouts.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :workout do
+    user { nil }
+    workout_date { "2025-10-02" }
+    notes { "MyText" }
+  end
+end

--- a/spec/models/workout_set_spec.rb
+++ b/spec/models/workout_set_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe WorkoutSet, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/workout_spec.rb
+++ b/spec/models/workout_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Workout, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
close #23 

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
Workoutモデル・WorkoutSetモデルの作成とマイグレーションを実装しました。  
ユーザーごとのトレーニング記録と、その詳細（セット単位の重量・回数・メモ）を保存できるようになります。
## 実装内容
<!-- 実装した内容を箇条書きで記載 -->
- Workoutモデルの作成
  - `user:references`（必須）
  - `workout_date:date`（必須）
  - `notes:text`（任意）
  - インデックス追加: `[:user_id, :workout_date]`
  - モデルにバリデーション追加
    - `workout_date` 必須
    - `notes` は最大500文字
  - 関連付け
    - `belongs_to :user`
    - `has_many :workout_sets, dependent: :destroy`
 

- WorkoutSetモデルの作成
  - `workout:references`（必須）
  - `exercise:references`（必須）
  - `set_number:integer`（必須, 1以上）
  - `weight:decimal(precision:5, scale:2)`（任意, 小数第2位まで）
  - `reps:integer`（任意）
  - `memo:text`（任意）
  - 複合ユニーク制約: `[:workout_id, :exercise_id, :set_number]`
  - モデルにバリデーション追加
    - `set_number` 必須、0以上
    - `weight/reps/memo` のいずれか必須（カスタムバリデーション）
  - 関連付け
    - `belongs_to :workout`
    - `belongs_to :exercise`

## 動作確認
<!-- 確認した動作や手順を記載 -->
- `rails db:migrate` が正常に実行されることを確認
- Railsコンソールで以下を確認
  ```ruby
  user = User.first
  workout = user.workouts.create!(workout_date: Date.today, notes: "胸トレ")

  exercise = Exercise.first

  # weight/reps あり
  workout.workout_sets.create!(exercise: exercise, set_number: 1, weight: 60, reps: 10)

  # memo のみ
  workout.workout_sets.create!(exercise: exercise, set_number: 2, memo: "フォーム重視")

  # 空 → 保存不可
  workout.workout_sets.create(exercise: exercise, set_number: 3)
  # => Validation failed: 重量、回数、メモのいずれかを入力してください

## 補足
<!-- 注意点や次回以降の対応予定があれば記載 -->
- Workoutは同日に複数レコードを持つことが可能です（朝・夜トレ対応）。
- WorkoutSetは「weight/reps/memo のいずれか」が必須で、空レコードは保存されません。
- MVPでは重量単位は kg 固定としています。将来的な lb 対応は拡張で検討します。