### PR TITLE
Deviseによるユーザー認証機能の実装（nameログイン対応）

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,16 @@ class User < ApplicationRecord
   enum gender: { unspecified: 0, male: 1, female: 2 }
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { minimum: 2 }
+
+  after_initialize :set_default_gendr, if: :new_record?
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  
+  private
+
+  def set_default_gendr
+    self.gender ||= :unspecified
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   has_many :workouts, dependent: :destroy
 
   enum gender: { male: 1, female: 2 }
+
+  validates :name, presence: true, length: { minimum: 2 }
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,9 @@
 class User < ApplicationRecord
   has_many :workouts, dependent: :destroy
 
-  enum gender: { male: 1, female: 2 }
+  enum gender: { unspecified: 0, male: 1, female: 2 }
 
-  validates :name, presence: true, length: { minimum: 2 }
+  validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { minimum: 2 }
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,6 +4,11 @@
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
+    <%= f.label :name %><br />
+    <%= f.text_field :name %>
+  </div>
+  
+  <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,8 +2,8 @@
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.label :name %><br />
+    <%= f.text_field :name, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="field">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:name]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,6 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
   config.authentication_keys = [:name]
 
   # Configure parameters from the request object used for authentication. Each entry
@@ -58,12 +59,14 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:email]
+  # config.case_insensitive_keys = [:email]
+  config.case_insensitive_keys = [:name]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:email]
+  # config.strip_whitespace_keys = [:email]
+  config.strip_whitespace_keys = [:name]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the

--- a/db/migrate/20251005001033_add_unique_index_to_users_name.rb
+++ b/db/migrate/20251005001033_add_unique_index_to_users_name.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToUsersName < ActiveRecord::Migration[7.1]
+  def change
+    add_index :users, "LOWER(name)", unique: true, name: "index_users_on_lower_name"
+  end
+end

--- a/db/migrate/20251005002253_change_users_gender_default.rb
+++ b/db/migrate/20251005002253_change_users_gender_default.rb
@@ -1,0 +1,6 @@
+class ChangeUsersGenderDefault < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :users, :gender, from: nil, to: 0
+    change_column_null :users, :gender, false, 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_10_02_125505) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_05_002253) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -45,8 +45,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_10_02_125505) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
-    t.integer "gender"
+    t.integer "gender", default: 0, null: false
     t.text "goal"
+    t.index "lower((name)::text)", name: "index_users_on_lower_name", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
close #16

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
Deviseを用いたユーザー認証機能を実装しました。
今回の対応では、メールアドレスではなくnameでログインできるように変更しています。
gender・goal は将来的にプロフィール編集画面から設定可能とし、サインアップ時点では自動的に未設定状態になります。
## 実装内容
<!-- 実装した内容を箇条書きで記載 -->
### ■ モデル
- `User` モデルに以下を追加  
  - `enum gender: { unspecified: 0, male: 1, female: 2 }`  
  - `validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { minimum: 2 }`  
  - `after_initialize :set_default_gender, if: :new_record?` により gender の初期値を自動設定  

### ■ Devise設定
- `config.authentication_keys = [:name]` に変更し、nameでのログインを有効化  
- `config.case_insensitive_keys`・`config.strip_whitespace_keys` に name を追加  

### ■ マイグレーション
-  AddUniqueIndexToUserName
  - nameにユニークインデックス（LOWER関連付き）を追加
- ChangeUsersGenderDefault
  - genderに`default: 0`, `null: fasle`を設定

### View
- `app/views/devise/registrations/new.html.erb`, `app/views/devise/sessions/new.html.erb` にnameの入力欄の追加
## 動作確認
<!-- 確認した動作や手順を記載 -->
- サインアップ時にname, email, passwordで登録できる
- genderが未選択でも自動で`unspecified`になる
- name + passwordでログイン可能
- ログイン時にルートページ（ / ) へリダイレクトされる
- サーバー再起動後も正常動作を確認
## 補足
<!-- 注意点や次回以降の対応予定があれば記載 -->
- 今後プロフィール編集画面で gender・goal の変更を可能にする
- goal 入力フォームの追加・バリデーション検討