### PR TITLE
ユーザー管理機能（プロフィール閲覧・編集）の実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,7 @@ class UsersController < ApplicationController
             redirect_to user_path, notice: "プロフィールを更新しました"
         else
             flash.now[:alert] = "入力内容に誤りがあります"
-            reder :edit, status: :unprocessable_entity
+            render :edit, status: :unprocessable_entity
         end
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,27 @@
+class UsersController < ApplicationController
+    before_action :authenticate_user!
+
+    def show
+        @user = current_user
+    end
+
+    def edit
+        @user = current_user
+    end
+
+    def update
+        @user = current_user
+        if @user.update(user_params)
+            redirect_to user_path, notice: "プロフィールを更新しました"
+        else
+            flash.now[:alert] = "入力内容に誤りがあります"
+            reder :edit, status: :unprocessable_entity
+        end
+    end
+
+    private
+
+    def user_params
+        params.require(:user).permit(:name, :gender, :goal)
+    end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,12 @@
   </head>
 
   <body>
+    <% flash.each do |key, message| %>
+      <div class="flash <%= key %>">
+        <%= message %>
+      </div>
+    <% end %>
+    
     <%= yield %>
   </body>
 </html>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,11 +1,6 @@
 <% if resource.errors.any? %>
   <div id="error_explanation" data-turbo-cache="false">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
+    <h2><%= "#{resource.errors.count}件のエラーが発生しました" %></h2>
     <ul>
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,27 @@
+<h2>プロフィール編集</h2>
+
+<%= form_with model: @user, url: user_path, method: :patch, local: true do |f| %>
+  <% if @user.errors.any? %>
+    <%= render "shared/error_messages", resource: @user %>
+  <% end %>
+
+  <div class="form-group">
+    <%= f.label :name, "名前" %>
+    <%= f.text_field :name, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :gender, "性別" %>
+    <%= f.select :gender, User.genders.keys.map { |k| [k, k] }, {}, class: "form-select" %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :goal, "目標" %>
+    <%= f.text_area :goal, rows: 3, class: "form-control" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "更新する", class: "btn btn-primary" %>
+    <%= link_to "戻る", user_path, class: "btn btn-secondary" %>
+  </div>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,28 @@
+<h2>プロフィール</h2>
+
+<div class="profile-section">
+  <p>名前：<%= @user.name %></p>
+  <%= link_to "編集", edit_user_path %>
+</div>
+
+<div class="profile-section">
+  <p>性別：<%= @user.gender %></p>
+  <%= link_to "編集", edit_user_path %>
+</div>
+
+<div class="profile-section">
+  <p>目標：<%= @user.goal.presence || "未設定" %></p>
+  <%= link_to "編集", edit_user_path %>
+</div>
+
+<hr>
+
+<div class="profile-section">
+  <p>メールアドレス：<%= @user.email %></p>
+  <%= link_to "変更", "#" %>
+</div>
+
+<div class="profile-section">
+  <p>パスワード：********</p>
+  <%= link_to "変更", "#" %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
   
-  # devise_scope :user do
-  #   root "devise/sessions#new"
-  # end
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  resource :user, only: [:show, :edit, :update]
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  root "users#show"
 end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the UsersHelper. For example:
+#
+# describe UsersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe UsersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
close #18 

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
ログインユーザーが自身のプロフィール情報（name, gender, goal）を閲覧・編集できる機能を追加しました。  
更新成功時・失敗時のフラッシュメッセージとエラーメッセージ表示を実装しています。
## 実装内容
<!-- 実装した内容を箇条書きで記載 -->
- `UsersController` を新規作成  
  - `show`, `edit`, `update` アクションを実装  
  - `before_action :authenticate_user!` を適用  
  - Strong Parameters に `:name, :gender, :goal` を許可  
- ルーティングを追加  
  ```ruby
  resource :user, only: [:show, :edit, :update]
- ビューを作成
  - `/app/views/users/show.html.erb`
    - プロフィール情報（name, gender, goal）を表示
    - email / password の変更リンクをダミーで設置
  - `/app/views/users/edit.html.erb`
    - name, gender, goal の編集フォームを実装
    - エラー時に `_error_message.html.erb` を表示
- `_error_messages.html.erb`を`app/views/shared/` に配置し共通化
- フラッシュメッセージ表示を `application.html.erb` に追加
## 動作確認
<!-- 確認した動作や手順を記載 -->
- ログイン状態で `/user` にアクセス → プロフィールが表示される
- 「編集」をクリックで `/user/edit` に遷移できる
- name, gender, goal を編集し更新 → 成功時にフラッシュが表示される
- 空欄送信時に `_error_messages` が表示される
- 未ログイン時に `/user` アクセス → ログイン画面へリダイレクトされ
- email / password のダミーリンクが表示されている
## 補足
<!-- 注意点や次回以降の対応予定があれば記載 -->
- 次ブランチ feature/devise-customize にて以下を実施予定
  - Devise 認証画面のカスタマイズ（Strong Parameters調整）
  - email / password 変更機能の追加
  - バリデーションメッセージの日本語化