### PR TITLE
本番環境 public/assets を正しく配信させるための修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,13 @@ Rails.application.configure do
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
+  # Render 本番で public/assets を配信
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
+  # Rails 7 + esbuild の JS を正しく圧縮・配信する設定
+  config.assets.js_compressor = :terser
+  # config.assets.css_compressor = :sass  # 必要なら
+  
   # Do not fall back to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 


### PR DESCRIPTION
## Branch
`fix/render-production-assets`

---

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
Render 本番環境で Stimulus が動作せず、`application.js` が 404 となる問題を修正する。  
原因は `public/assets` 配信設定が無効だったため、本番でビルド済み JS が配信されていなかったこと。

---

## 実装内容
<!-- 実装した内容を箇条書きで記載 -->
- `config/environments/production.rb` に以下を追記  
  - `config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?`  
  - `config.assets.js_compressor = :terser`
- Render 側で `RAILS_SERVE_STATIC_FILES=true` を利用する想定で設定を整理

---

## 動作確認
<!-- 確認した動作や手順を記載 -->
- [ ] デプロイ後 `/assets/application.js` にアクセスして 200 が返ることを確認  
- [ ] カレンダー画面で FullCalendar が正しく表示される  
- [ ] 種目選択画面が正常に動作する  
- [ ] セット入力画面で行追加など Stimulus が動作する  
- [ ] ブラウザコンソールに `GET /assets/application.js 404` が出ていない  

---

## 関連issue
- close #100 

---

## 補足
<!-- 注意点や次回以降の対応予定があれば記載 -->
- CSS 圧縮設定（`config.assets.css_compressor`）は今回の対応には含めず、必要なら別対応とする  
- Render 側の環境変数 `RAILS_SERVE_STATIC_FILES=true` が設定されていることを要確認  