### PR TITLE
Sprockets と非互換の terserの記載の削除

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,10 +27,6 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
   # Render 本番で public/assets を配信
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
-
-  # Rails 7 + esbuild の JS を正しく圧縮・配信する設定
-  config.assets.js_compressor = :terser
-  # config.assets.css_compressor = :sass  # 必要なら
   
   # Do not fall back to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
## Branch
`fix/production-assets-config`

---

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
本番環境（Render）で `application.js` が 404 エラーとなり、  
カレンダー／種目選択／セット入力など Stimulus を利用した機能が全て動作しない不具合を修正した。

原因となっていた  
`config.assets.js_compressor = :terser`  
が Sprockets のサポート外であるため、assets:precompile 時にエラーが発生し、JS ビルド成果物が出力されていなかった。

本 PR では当該行を削除し、アセットが正常に配信される状態に戻す。

---

## 実装内容
<!-- 実装した内容を箇条書きで記載 -->
- `config/environments/production.rb`  
  - `config.assets.js_compressor = :terser` の削除
- その他設定（`RAILS_SERVE_STATIC_FILES=true`）は現状維持

---

## 動作確認
<!-- 確認した動作や手順を記載 -->
- [ ] `/assets/application.js` にアクセスして 200 が返ること  
- [ ] カレンダー画面が正常に表示される  
- [ ] 種目選択画面が正常に表示・動作する  
- [ ] セット入力画面で Stimulus の処理が動作する  
- [ ] ブラウザコンソールに JS の 404 エラーが表示されない  
- [ ] デプロイログに Sprockets の compressor エラーが出ない

---

## 関連issue
- close #102 

---

## 補足
<!-- 注意点や次回以降の対応予定があれば記載 -->
- 本 PR は本番環境復旧が目的のため、必要最小限の修正のみを行っている  
- アセット周りの構成（esbuild / Sprockets）の整理は別Issueにて検討予定
