### PR TITLE
Feature/setup sendgrid production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
     user_name: "apikey",
     password: ENV["SENDGRID_API_KEY"],
     authentication: :plain,
-    enabled_starttls_auto: true
+    enable_starttls_auto: true
   }
 
   config.action_mailer.default_options = { from: ENV["MAILER_SENDER"] }


### PR DESCRIPTION
## Branch  
feature/setup-sendgrid-production

## 概要  
本番環境でのメール送信（Devise のパスワード再設定メール等）を安定して行うため、  
SendGrid を使用した SMTP 設定を追加した。  
Render 側の `SENDGRID_API_KEY`・`SMTP_*` の準備を前提とし、Rails の production 環境で SendGrid 経由の送信が可能な状態にする。

## 対応内容  
- production.rb を更新し、SendGrid 用の ActionMailer 設定を追加  
- ENV 経由で `SENDGRID_API_KEY` を読み込む構成に統一  
- デプロイ時に本番メール送信機能が動作するように整理  
- 開発環境の Gmail 設定とは区別する形で本番用 SMTP 設定のみ追加

## 動作確認項目  
- [ ] PR をマージ後、Render にデプロイされる  
- [ ] SendGrid の Sender Authentication が「Verified」になっていること  
- [ ] Render の Environment Variables に下記が設定されている  
  - SENDGRID_API_KEY  
  - SMTP_DOMAIN（任意）  
  - RAILS_ENV=production  
- [ ] パスワード再設定メールを本番環境のログイン画面から送信し、宛先メールに届くこと  
- [ ] メール内リンクを踏んで、正しくパスワード再設定画面へ遷移すること  
- [ ] メールテンプレートがアプリのデザイン方針に沿っていること

## 関連 Issue  
- close #126 

## 備考  
- Sender Authentication は "Single Sender Verification" で登録済み  
- API Key は **Full Access** ではなく **Restricted (Mail Send のみ)** が推奨  
- 本番メール機能は Render の "Starter" プランで利用できる  
