### PR TITLE
本番用API実装「取得専用（GETのみ）」

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -11,7 +11,7 @@ class Api::EventsController < ApplicationController
     workouts = current_user.workouts.where(workout_date: start_date..end_date).order(:workout_date)
 
     events = workouts.map do |w|
-      { id: w.id, title: "Training", start: w.workout_date.to_s, end: nil, body_part: nil }
+      { id: w.id, start: w.workout_date.to_s, end: nil }
     end
 
     render json: events


### PR DESCRIPTION
## Branch
`feature/api-calendar-events`

---

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
React FullCalendar と連携するため、Rails API に「記録済み日付（Workout が存在する日付）」を返却するエンドポイントを実装した。  
FullCalendar 標準仕様である `start` / `end` パラメータ方式に対応し、指定された日付範囲に含まれるユーザーの Workout を JSON 形式で返す。

本 API は「取得専用（GET のみ）」とし、Workout の新規作成・更新・削除は既存の UI で行うため、POST / PATCH / DELETE の実装は行わない。

---

## 実装内容
<!-- 実装した内容を箇条書きで記載 -->
- `GET /api/events` を start/end 方式で実装
  - `/api/events?start=YYYY-MM-DD&end=YYYY-MM-DD`
- 必須パラメータ（start, end）が欠けている場合は `400 Bad Request` を返却
- `workout_date` を用いて範囲内の Workout を取得
- 返却 JSON を React 側の `CalendarEvent` 型（`id`, `start`, `end`）と完全一致させた
- 仮実装（year/month 方式）を削除し、本番 API 仕様に統一

## 返却 JSON 形式
```json
{
  "id": 1,
  "start": "2025-12-01",
  "end": null
}
```

---

## 動作確認
<!-- 確認した動作や手順を記載 -->
- `/api/events?start=2025-11-01&end=2025-11-30` で正しく JSON が返る
- Rails ログで start / end パラメータが正しく受信されている
- Workout の `workout_date` が範囲内のものだけが返る
- TypeScript の `CalendarEvent` 型（id, start, end）と完全一致する構造が返ってくる
- パラメータが欠落した場合に `400 Bad Request` が返る
- コンソール・Rails ログともにエラーなし

---

## 関連issue
- close #157 

---

## 補足
<!-- 注意点や次回以降の対応予定があれば記載 -->
- title / body_part などの追加データは、後続の UI/UX 強化 Issue（#160〜#161）で必要になった時点で API 拡張予定  
- 現段階では「記録のある日付をカレンダーに反映する」ことを最優先し、最小限の JSON 構造に絞っている
