### PR TITLE
React FullCalendar 「API 連携」の実装

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -11,7 +11,7 @@ class Api::EventsController < ApplicationController
     workouts = current_user.workouts.where(workout_date: start_date..end_date).order(:workout_date)
 
     events = workouts.map do |w|
-      { id: w.id, start: w.workout_date.to_s, end: nil }
+      { id: w.id, start: w.workout_date.to_s }
     end
 
     render json: events

--- a/app/javascript/react/components/calendar/CalendarGrid.tsx
+++ b/app/javascript/react/components/calendar/CalendarGrid.tsx
@@ -1,6 +1,7 @@
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
+import { fetchCalendarEvents } from "react/services/calendarApi";
 
 export default function CalendarGrid() {
   return (
@@ -16,6 +17,10 @@ export default function CalendarGrid() {
         }}
         height={700}
         dayCellClassNames="fc-daycell"
+        events = {async (info, successCallback) => {
+          const events = await fetchCalendarEvents(info.startStr, info.endStr);
+          successCallback(events);          
+        }}
       />
     </div>
   );

--- a/app/javascript/react/services/calendarApi.ts
+++ b/app/javascript/react/services/calendarApi.ts
@@ -11,7 +11,13 @@ export async function fetchCalendarEvents(start: string,end: string): Promise<Ca
       return [];
     }
 
-    return res.json();
+    const data = await res.json();
+
+    return data.map((e: any) => ({
+      id: String(e.id),
+      start: e.start,
+      end: e.end ?? undefined
+    }));
   } catch (err) {
     console.error("Network Error:", err);
     return [];

--- a/app/javascript/react/types/calendar.ts
+++ b/app/javascript/react/types/calendar.ts
@@ -1,5 +1,5 @@
 export type CalendarEvent = {
-  id: number;    // workout の ID
+  id: string;    // workout の ID
   start: string;
-  end: string | null;
+  end?: string;
 };


### PR DESCRIPTION
## Branch
`feature/react-calendar-render`

---

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
React FullCalendar と Rails API を正式に接続し、  
「ワークアウトの存在する日付をカレンダーへ反映する」データ連携を実装した。

FullCalendar の `events` 関数を機能させるため、  
start / end 方式で Rails API を呼び出し、返却された JSON を FullCalendar 形式へ整形して描画する。

---

## 実装内容
<!-- 実装した内容を箇条書きで記載 -->
### ● calendarApi.ts
- `fetchCalendarEvents(start, end)` を本番仕様に仕上げた  
  - `/api/events?start=YYYY-MM-DD&end=YYYY-MM-DD` を fetch  
  - HTTP エラー・Network エラー時は FullCalendar が壊れないように空配列を返す  
  - FullCalendar の EventInput と整合性を取るため  
    - `id` → string 化  
    - `end: null` → `end?: undefined` に変換  
- FullCalendar と TypeScript の型エラーを完全解消

### ● CalendarGrid.tsx
- `<FullCalendar />` に `events` function を追加  
  - `info.startStr` / `info.endStr` を API の start/end として渡す  
  - API から取得した events を `successCallback(events)` で描画  
  - API 停止時でも UI 全体がクラッシュしない安全設計に統一  
- prev / next / today の月切替時に正しく API が再実行されることを確認

---


## 動作確認
<!-- 確認した動作や手順を記載 -->
- 初期表示で API が自動実行され、該当月のイベントが描画される  
- Workout が存在する日に FullCalendar の dot が表示される  
- 月移動で start/end の範囲が変わり、API が正常に更新される  
- API レスポンスが空配列の場合でも FullCalendar が正常表示される  
- API 停止（Rails サーバー停止）時に console にエラーが出るが UI は壊れない  
- TypeScript の型エラーがすべて解消された

---

## 関連issue
- close #158 

---

## 補足
<!-- 注意点や次回以降の対応予定があれば記載 -->
- ローディング UI（読み込み中のスピナーなど）は次の issue #159 にて実装予定  
- title / body_part は現段階では未利用のため、必要になれば後続 issue で拡張する
