### PR TITLE
React FullCalendar「日付クリックイベントの追加」

### DIFF
--- a/app/javascript/react/components/calendar/CalendarGrid.tsx
+++ b/app/javascript/react/components/calendar/CalendarGrid.tsx
@@ -3,7 +3,7 @@ import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import { fetchCalendarEvents } from "react/services/calendarApi";
-import type { EventSourceFuncArg, EventInput } from "@fullcalendar/core";
+import type { EventSourceFuncArg, EventInput, EventClickArg } from "@fullcalendar/core";
 import type { DateClickArg } from "@fullcalendar/interaction";
 
 export default function CalendarGrid() {
@@ -50,6 +50,11 @@ export default function CalendarGrid() {
     }
   };
 
+  const handleEventClick = (info: EventClickArg ) => {
+    const workoutId = info.event.id;
+    window.location.href = `/workouts/${workoutId}`;
+  };
+
   return (
     <div style={{ marginTop: "1rem", position: "relative" }}>
       <FullCalendar
@@ -65,6 +70,7 @@ export default function CalendarGrid() {
         dayCellClassNames="fc-daycell"
         events={handleEvents}
         dateClick={handleDateClick}
+        eventClick={handleEventClick}
       />
       {loading && <div style={overlayStyle}>Loading...</div>}
     </div>


### PR DESCRIPTION
## Branch
`feature/calendar-date-click`

---

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
React FullCalendar に以下の挙動を実装し、MVP 時点のカレンダー UX を再現した。

- 日付クリック（dateClick）：  
  Workout が存在しない日 → `/workouts/select_exercise?date=YYYY-MM-DD` へ遷移  
  Workout が存在する日 → `/workouts/:id` へ遷移

- イベントクリック（eventClick）：  
  青丸（イベント）をクリックした場合も `/workouts/:id` へ遷移するようにした

これにより「その日の Workout が既にあるかどうか」で遷移先を自動分岐し、  
ユーザーが迷わない自然なUXが実現できた。

---

## 実装内容
<!-- 実装した内容を箇条書きで記載 -->
### 日付クリックの改善（dateClick）
- クリックされた日付（info.dateStr）を元に `/api/events?start=end=YYYY-MM-DD` を取得
- 返却結果に Workout が存在する場合  
  → `window.location.href = /workouts/:id`
- 存在しない場合  
  → `window.location.href = /workouts/select_exercise?date=YYYY-MM-DD`
- MVP と同じ導線を React カレンダーに移植

### イベントクリックの追加（eventClick）
- FullCalendar に eventClick を追加
- `info.event.id` を元に `/workouts/:id` へ遷移
- 青丸（既存 Workout）のクリック時に正しく反応するよう仕様を統一

### その他
- ローディング UI（読み込み中の overlay）と干渉しないことを確認
- dateClick / eventClick どちらも UX が自然になるよう調整
- 型エラー（DateClickArg / EventClickArg）を適切に import して解消

---

## 動作確認
<!-- 確認した動作や手順を記載 -->
- [x] Workout が存在しない日のクリックで `/workouts/select_exercise?date=YYYY-MM-DD` に遷移する
- [x] Workout が存在する日のクリックで `/workouts/:id` に遷移する
- [x] 青丸（イベント）をクリックした場合も `/workouts/:id` に遷移する
- [x] スマホ・PC どちらでも正常に遷移する
- [x] ローディング overlay の表示に影響がない
- [x] カレンダー UI の崩れがない

---

## 関連issue
- close #166 

---

## 補足
<!-- 注意点や次回以降の対応予定があれば記載 -->
- この PR は UX（挙動）の実装を優先しており、UI（デザイン）の調整は後続の #168 / #160 にて行う予定。
- Workout が1日に複数存在しない前提の設計に基づくため、返却イベントは1件のみを想定して遷移先を決定している。
