### PR TITLE
FullCalendarのCSSにモバイル版のCSSを追加

### DIFF
--- a/app/javascript/react/components/calendar/CalendarGrid.tsx
+++ b/app/javascript/react/components/calendar/CalendarGrid.tsx
@@ -66,7 +66,7 @@ export default function CalendarGrid() {
           center: "title",
           right: "prev,next today"
         }}
-        height={700}
+        height="auto"
         dayCellClassNames="fc-daycell"
         events={handleEvents}
         dateClick={handleDateClick}

--- a/app/javascript/styles/fullcalendar.scss
+++ b/app/javascript/styles/fullcalendar.scss
@@ -1,5 +1,5 @@
 /* --- FullCalendar ヘッダー白帯削除（最重要） --- */
-.fc-scrollgrid-section-sticky {
+  .fc-scrollgrid-section-sticky {
     background: transparent !important;
     border-color: transparent !important;
   }
@@ -66,5 +66,32 @@
     background: transparent !important;
   }
 
+  @media (max-width: 480px) {
+
+    /* 日付セルの高さ調整（最重要） */
+    .fc .fc-daygrid-day-frame.fc-scrollgrid-sync-inner {
+      height: 42px !important;
+      min-height: 42px !important;
+      padding: 0 !important;
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+    }
+  
+    /* 日付数字の位置＋サイズ調整 */
+    .fc .fc-daygrid-day-number {
+      font-size: 0.8rem !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      line-height: 42px !important;
+      display: inline-block !important;
+    }
+  
+    /* イベントが縦方向に押しつぶさないよう縮小 */
+    .fc .fc-daygrid-event {
+      font-size: 0.6rem !important;
+      padding: 1px 3px !important;
+    }
+  }
   
   


### PR DESCRIPTION
## Branch
`feature/calendar-mobile-ui-basic`

---

## 概要
React FullCalendar のスマホ表示において、日付セルが縦に長くなる問題や、数字位置・イベント表示の不整合があったため、最小限のレスポンシブ改善を行った。

本 PR では PC 版には影響を与えず、スマホでの可用性（見やすさ・タップしやすさ）を確保することに目的を絞る。デザイン面の大幅な調整や「日付セルを丸で囲む UI」などは後続 Issue（#160）で対応する。

---

## 対応内容
- `.fc-scrollgrid-section-sticky` の背景白帯を削除（background / border を透明化）
- カレンダーコンテナ `#calendar` にダーク UI（背景色・角丸・枠線・影）を適用
- タイトル（`.fc-toolbar-title`）、曜日ラベル（`.fc-col-header-cell-cushion`）のフォントスタイル・カラー調整
- 日付セル（`.fc-daygrid-day`）・日付数字（`.fc-daygrid-day-number`）のベーススタイル調整
- 今日の日付（`.fc-day-today .fc-daygrid-day-number`）の強調表示（背景＋枠線＋丸型）

### スマホ向けレスポンシブ（@media max-width: 480px）
- `.fc-daygrid-day-frame.fc-scrollgrid-sync-inner` の高さを 42px に統一し、縦方向に長くなりすぎないよう調整
- `.fc-daygrid-day-number` のフォントサイズ・余白・line-height を調整し、セル中央に数字が表示されるように変更
- `.fc-daygrid-event` のフォントサイズ・padding を縮小し、日付セルの高さを圧迫しないように調整

## 変更ファイル
- `app/assets/stylesheets/fullcalendar.scss`

---

## 動作確認項目
- [x] スマホ画面（DevTools のレスポンシブモードおよび実機）で、日付セルが縦に伸びすぎず均一な高さで表示される
- [x] 日付数字がセル中央に表示され、視認性・タップのしやすさが向上している
- [x] 今日の日付が想定どおり強調表示されている
- [x] イベント表示が極端に潰れたりレイアウト崩れを起こしていない（最終的な UI は後続 Issue で調整予定）
- [x] PC 表示ではレイアウト崩れや意図しないスタイル変更が発生していない

---

## 関連issue
- close #161 

---

## 備考
- 本 PR はスマホ UI の「基本的な操作性の確保」が目的であり、丸型 UI や配色変更などのデザインリニューアルは #160 にて対応予定。
- 現状のイベント表示（帯状の「Training」ラベル）は、将来的に「日付セルを丸で囲う UI」へ置き換える前提のため、本 PR では最低限の調整に留めている。
- Stimulus カレンダー削除後も、今回追加した CSS は React FullCalendar 用としてそのまま利用可能。
