### PR TITLE
独自ドメインの取得及びメール設定調整

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,13 +28,13 @@ Rails.application.configure do
   # Render 本番で public/assets を配信
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
-  config.action_mailer.default_url_options = { host: "my-training-log.onrender.com", protocol: "https" }
+  config.action_mailer.default_url_options = { host: "my-training-log.com", protocol: "https" }
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address: "smtp.sendgrid.net",
     port: 587,
-    domain: "my-training-log.onrender.com",
+    domain: "my-training-log.com",
     user_name: "apikey",
     password: ENV["SENDGRID_API_KEY"],
     authentication: :plain,


### PR DESCRIPTION
## Branch
`feature/setup-custom-domain`

---

## 概要
本番環境に **独自ドメイン（apex）** を設定し、  
それに伴い Google ログイン（OAuth）および ActionMailer の URL / domain 設定を独自ドメインへ統一しました。

既存の Render 提供ドメイン（`*.onrender.com`）は削除せず、  
補助的に残したまま正規ドメインを独自ドメインとしています。

---

## 背景
- 本リリース要件として独自ドメイン対応が必要
- OGP 実装済みのため、URL の正規化が必要
- Google ログイン・メール内リンクが旧ドメインのままにならないよう整理する必要があった

---

## 対応内容

### 1. 独自ドメイン設定（Render / Cloudflare）
- Cloudflare Registrar にて独自ドメインを取得
- Cloudflare DNS に A レコードを設定
- Render の Custom Domain に apex ドメインを追加
- SSL（HTTPS）が自動発行されることを確認

---

### 2. Google OAuth 設定変更
- Google Cloud Console の OAuth 設定に独自ドメインを追加
  - Authorized JavaScript origins
  - Authorized redirect URIs
- 独自ドメイン経由で Google ログインが正常に動作することを確認
- 旧 `onrender.com` の設定は当面残す方針とした

---

### 3. Rails 本番設定の更新
- `config/environments/production.rb` を修正
  - `action_mailer.default_url_options` を独自ドメインに変更
  - `smtp_settings[:domain]` を独自ドメインに変更
- メール内リンクが独自ドメインで生成されるように統一

---

## 変更内容（コード）
- `config/environments/production.rb`
  - Mailer の host / domain 設定を独自ドメインへ更新

---

## 動作確認項目
- [x] 独自ドメイン（https）でトップページにアクセスできる
- [x] 独自ドメイン経由で Google ログインが成功する
- [x] パスワードリセット等のメール URL が独自ドメインになっている
- [x] OGP が独自ドメイン URL で正しく表示される
- [x] 既存機能・ログイン後画面に影響がない

---

## 旧ドメインの扱いについて
- Render 提供の `*.onrender.com` ドメインは削除せず残している
- 正規 URL は独自ドメインとし、段階的な切り替えとした

---

## 関連issue
- close #181 

---

## 備考
- DNS / SSL / OAuth はすべて外部サービス側で設定完了済み
- 今回の PR は Rails 側の設定整理を主目的とする
