### PR TITLE
有効draftがない場合の遷移の戻るボタン遷移の不具合の修正

### DIFF
--- a/app/javascript/controllers/sets_controller.js
+++ b/app/javascript/controllers/sets_controller.js
@@ -124,6 +124,12 @@ export default class extends Controller {
 
   commitOrBack() {
     const drafts = this.collectDrafts()
+
+    if (!this.editModeValue && drafts.length === 0) {
+      window.location.href = `/workouts/select_exercise?date=${this.dateValue}`
+      return
+    }
+    
     this.commit()
   }
 


### PR DESCRIPTION
## Branch
`feature/fix-back-navigation-without-draft`

---

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
セット追加（CREATE）画面において、有効な localStorage draft が存在しない状態で
戻るボタンを押下した際、本来は種目選択画面へ遷移すべきところ、
何も起きず画面が停止してしまう不具合を修正しました。

draft 前提設計に沿って、状態に応じた正しい戻る挙動を実装しています。

---

## 実装内容
<!-- 実装した内容を箇条書きで記載 -->
- `sets_controller.js` の `commitOrBack()` に分岐処理を追加
- CREATE 画面かつ有効な draft が 0 件の場合
  - 保存処理を行わず
  - 種目選択画面へ遷移するよう修正
- EDIT 画面および draft が存在するケースの挙動には影響なし

---

## 修正内容（要点）

- `commit()` は保存責務のみに限定
- 「何も入力していない場合の戻る」は `commitOrBack()` 側で制御
- localStorage / DB / 既存削除フローへの影響なし

---

## 動作確認
<!-- 確認した動作や手順を記載 -->

- [x] CREATE 画面で何も入力せず戻る → 種目選択画面へ遷移する
- [x] CREATE 画面で入力あり → 通常どおり保存・遷移する
- [x] 前回値コピー後に戻る → 正しく保存される
- [x] EDIT 画面での保存・削除フローに影響がないこと

---

## 関連issue
- close #205 

---

## 補足
<!-- 注意点や次回以降の対応予定があれば記載 -->
- localStorage を用いた draft 前提設計における UX 不整合の修正
- 前回値コピー機能の追加によって顕在化したが、単独でも再現する不具合
- 差分は `sets_controller.js` のみで、影響範囲は限定的
