### PR TITLE
Avatar スコア加算用ロジックの実装

### DIFF
--- a/app/services/avatar/score_increment_service.rb
+++ b/app/services/avatar/score_increment_service.rb
@@ -1,15 +1,51 @@
 module Avatar
   class ScoreIncrementService
+    BODY_PART_TO_AVATAR_PART = {
+      '胸' => :upper_body,
+      '背中' => :upper_body,
+      '肩' => :upper_body,
+      '腕' => :upper_body,
+      '腹' => :core,
+      '脚' => :lower_body
+    }.freeze
+
     def initialize(workout_set)
       @workout_set = workout_set
     end
 
     def call
-      # TODO: 実装は次ステップ
+      return unless should_increment?
+
+      increment_point!
     end
 
     private
 
     attr_reader :workout_set
+
+    def should_increment?
+      workout_set.created_at == workout_set.updated_at
+    end
+
+    def increment_point!
+      avatar_part_stat.increment!(:point, 1)
+      avatar_part_stat.update!(last_trained_at: Time.current)
+    end
+
+    def avatar_part
+      BODY_PART_TO_AVATAR_PART.fetch(body_part_name)
+    end
+
+    def body_part_name
+      workout_set.exercise.body_part.name
+    end
+
+    def user
+      workout_set.workout.user
+    end
+
+    def avatar_part_stat
+      user.avatar_part_stats.find_or_create_by!(avatar_part: avatar_part)
+    end
   end
 end


### PR DESCRIPTION
## Branch
`feature/avatar-score-increment`

---

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
WorkoutSet 作成時をトリガーとして、  
対象の BodyPart を AvatarPart に変換し、  
対応する `avatar_part_stats` のスコア（point）を加算するロジックを実装しました。

本 PR では、アバター成長処理の中核となる  
**変換・加算・二重加算防止を含む Service 層の実装** を行い、  
後続の減衰処理・表示ロジック実装に進めるための基盤を整えています。

---

## 実装内容
<!-- 実装した内容を箇条書きで記載 -->
- `Avatar::ScoreIncrementService` を新規作成
- BodyPart → AvatarPart の固定変換ルールを Service 内に集約
- WorkoutSet 作成時のみ point を加算する仕様を実装
- `avatar_part_stats` を遅延生成（`find_or_create_by`）
- `last_trained_at` を更新
- Service 内判定により二重加算を防止
- Controller / Model callback にはロジックを置かない設計を維持

---

## 実装仕様

### 加算トリガー
- WorkoutSet **作成時のみ** スコア加算
- update / 再保存時は加算しない

### BodyPart → AvatarPart 変換
| BodyPart | AvatarPart |
|---------|------------|
| 胸 / 背中 / 肩 / 腕 | upper_body |
| 腹 | core |
| 脚 | lower_body |

### スコア加算方式
- 固定値加算（1 WorkoutSet につき +1）
- volume（weight × reps）等は本 PR では扱わない

### 二重加算防止
- `created_at == updated_at` の場合のみ加算することで、
  同一 WorkoutSet に対する複数回加算を防止

---

## 動作確認
<!-- 確認した動作や手順を記載 -->
- [x] WorkoutSet 作成時に `avatar_part_stats.point` が +1 される
- [x] avatar_part_stats が存在しない場合でも正常に生成される
- [x] 同一 WorkoutSet を update しても point が増えない
- [x] BodyPart に応じて正しい AvatarPart が選択される

---

## 関連issue
- close #212 

---

## 補足
<!-- 注意点や次回以降の対応予定があれば記載 -->
- 本 PR ではレベル計算・減衰処理・React 連携は行っていません
- 成長ロジックは Service 層に集約しており、将来的な拡張が容易な構成になっています