### PR TITLE
アバタースコア減衰処理の実装

### DIFF
--- a/app/services/avatar/score_decay_service.rb
+++ b/app/services/avatar/score_decay_service.rb
@@ -1,0 +1,36 @@
+module Avatar
+  class ScoreDecayService
+    def initialize(avatar_part_stat)
+      @avatar_part_stat = avatar_part_stat
+    end
+
+    def call
+      apply_decay!
+    end
+
+    private
+
+    attr_reader :avatar_part_stat
+
+    def elapsed_days
+      return 0 if avatar_part_stat.last_trained_at.nil?
+
+      ((Time.current - avatar_part_stat.last_trained_at) / 1.day).floor
+    end
+
+    def decay_amount
+      elapsed_days
+    end
+
+    def apply_decay!
+      return if decay_amount <= 0
+
+      new_point = [avatar_part_stat.point - decay_amount, 0].max
+
+      avatar_part_stat.update!(
+        point: new_point,
+        last_trained_at: Time.current
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Branch
`feature/avatar-score-dacay`

---

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
アバター成長スコア（avatar_part_stats.point）について、  
最後のトレーニング日時からの経過時間に応じてスコアを減衰させる  
**遅延計算方式の減衰処理** を実装しました。

本 PR では、定期バッチ等は用いず  
**アバター表示前に Service を通すことで常に最新状態へ正規化する**
設計を採用しています。

---

## 実装内容
<!-- 実装した内容を箇条書きで記載 -->
- アバター成長スコア減衰用 Service を新規実装
  - `Avatar::ScoreDecayService`
- `last_trained_at` を起点とした経過日数ベースの減衰処理
- 1日ごとに固定値でスコアを減衰
- スコア下限を 0 に固定
- 減衰適用後に基準日時を更新することで二重減衰を防止
- 成長処理（ScoreIncrementService）とは責務を分離

---

## 設計方針
- 減衰対象は `avatar_part_stats.point` を直接更新
- 表示用の仮想値計算は行わない
- cron / batch 等の定期処理は使用せず、遅延計算方式を採用
- Controller / Model callback にはロジックを置かず Service に集約

---

## 動作確認
<!-- 確認した動作や手順を記載 -->
rails console にて以下を確認

- 経過日数に応じてスコアが減衰すること
- スコアが 0 未満にならないこと
- 同一条件で複数回 Service を呼んでも二重減衰が発生しないこと
- `last_trained_at` が減衰適用後に更新されること

---

## 関連issue
- close #214 

---

## 補足
<!-- 注意点や次回以降の対応予定があれば記載 -->
本 PR でアバター成長ロジック（加算・減衰）の基盤が整ったため、  
次の issue では **アバター表示用データ取得基盤（Controller / API）** の実装を行う予定です。