### PR TITLE
有酸素セット編集のlocalDraftでの値の変更を改装

### DIFF
--- a/app/javascript/controllers/cardio_set_create_controller.js
+++ b/app/javascript/controllers/cardio_set_create_controller.js
@@ -31,18 +31,38 @@ export default class extends Controller {
     const uuid = this.uuid()
     if (!uuid) return
 
-    const raw = localStorage.getItem(this.key(uuid))
-    if (!raw) return
+    const key = this.key(uuid)
+    const raw = localStorage.getItem(key)
 
-    try {
-      const data = JSON.parse(raw)
-      this.distanceTarget.value = data.distance ?? ""
-      this.durationTarget.value = data.duration ?? ""
-      this.caloriesTarget.value = data.calories ?? ""
-      this.paceTarget.value = data.pace ?? ""
-      this.memoTarget.value = data.memo ?? ""
-    } catch {
-      localStorage.removeItem(this.key(uuid))
+    // ① draft があれば復元
+    if (raw) {
+      try {
+        const data = JSON.parse(raw)
+        this.distanceTarget.value = data.distance ?? ""
+        this.durationTarget.value = data.duration ?? ""
+        this.caloriesTarget.value = data.calories ?? ""
+        this.paceTarget.value = data.pace ?? ""
+        this.memoTarget.value = data.memo ?? ""
+        return
+      } catch {
+        localStorage.removeItem(key)
+        return
+      }
+    }
+
+    // ② 編集画面なら初期値から draft を生成
+    if (this.isEdit()) {
+      const payload = {
+        distance: this.distanceTarget.value,
+        duration: this.durationTarget.value,
+        calories: this.caloriesTarget.value,
+        pace: this.paceTarget.value,
+        memo: this.memoTarget.value
+      }
+
+      if (Object.values(payload).some(v => v && v !== "")) {
+        localStorage.setItem(key, JSON.stringify(payload))
+      }
     }
   }
 
@@ -52,5 +72,10 @@ export default class extends Controller {
 
   key(uuid) {
     return `cardio_set_draft:${uuid}`
+  }
+
+  isEdit() {
+    const row = this.element.closest(".set-input-row")
+    return row?.dataset.persisted === "true"
   }
 }

--- a/app/javascript/controllers/cardio_sets_controller.js
+++ b/app/javascript/controllers/cardio_sets_controller.js
@@ -53,6 +53,15 @@ export default class extends Controller {
       this.appendHidden(form, `sets[${draft.uuid}][pace]`, draft.pace)
       this.appendHidden(form, `sets[${draft.uuid}][memo]`, draft.memo)
     })
+
+    const deletedIds = this.collectDeletedSetIds()
+    deletedIds.forEach((id) => {
+      this.appendHidden(form, `sets[${id}][_destroy]`, "1")
+    })
+
+    drafts.forEach(draft => {
+      localStorage.removeItem(`cardio_set_draft:${draft.uuid}`)
+    })
   
     form.requestSubmit()
   }
@@ -61,9 +70,8 @@ export default class extends Controller {
     const drafts = this.collectDrafts()
 
     if (!this.editModeValue && drafts.length === 0) {
-        if (!this.dateValue) return
-        window.location.href = `/workouts/select_exercise?date=${this.dateValue}`
-        return
+      window.location.href = `/workouts/select_exercise?date=${this.dateValue}`
+      return
     }
     
     this.commit()
@@ -98,6 +106,26 @@ export default class extends Controller {
   
     return drafts
   }
+
+  collectDeletedSetIds() {
+    const deletedIds = []
+  
+    this.listTarget.querySelectorAll(".set-input-row").forEach((row) => {
+      const uuid = row.dataset.setUuid
+      const persisted = row.dataset.persisted === "true"
+  
+      if (!persisted) return
+  
+      const key = `cardio_set_draft:${uuid}`
+      const draft = localStorage.getItem(key)
+  
+      if (!draft) {
+        deletedIds.push(uuid)
+      }
+    })
+  
+    return deletedIds
+  }  
   
   validDraft(data) {
     return data.distance || data.duration || data.calories || data.pace || data.memo

--- a/app/views/cardio_sets/edit_group.html.erb
+++ b/app/views/cardio_sets/edit_group.html.erb
@@ -10,6 +10,11 @@
     <div data-controller="cardio-sets"
          data-cardio-sets-edit-mode-value="true">
 
+      <div class="floating-back"
+           data-action="click->cardio-sets#commitOrBack">
+           ←
+      </div>
+
       <div data-cardio-sets-target="list">
         <% @sets.each_with_index do |set, i| %>
           <div class="set-input-row mb-3 p-3 rounded"
@@ -46,12 +51,7 @@
               data-action="cardio-sets#add">
         ＋ セットを追加
       </button>
-
-      <button type="button"
-              class="btn btn-primary w-100 mt-3"
-              data-action="cardio-sets#commit">
-        保存
-      </button>
+      
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
## Branch
`feature/cardio-refactor-ui-ux`

---

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
既存の筋トレ記録フローと同一の UX を維持しつつ、  
**有酸素トレーニングを筋トレとは別モデルとして記録できる仕組み**を追加した。

本 PR では「記録・編集・削除・日付単位での整合性」までを対象とし、  
**カレンダー表示・レポート・React 側の表示調整は含めない。**

---

## 背景 / 目的
- 現在は筋トレ（重量・回数）しか扱えない
- 有酸素は距離・時間・カロリー等、性質が異なる
- 無理に Workout / WorkoutSet に統合せず、別モデルとして整理したい
- ただし UX は既存の筋トレフローと分断しない

---

## 実装内容
<!-- 実装した内容を箇条書きで記載 -->

### 1. BodyPart に「有酸素」を追加
- 既存部位（胸 / 背中 / 肩 …）の最下部に配置
- 今回は「有酸素」部位のみ作成
- 有酸素専用種目（ランニング等）は未導入

---

### 2. 有酸素用データモデルの追加
筋トレとは完全に別モデルとして定義。

#### CardioWorkout
- user_id
- exercise_id（将来拡張用）
- body_part_id（有酸素）
- performed_on
- memo（任意）

#### CardioSet
- cardio_workout_id
- distance
- duration
- calories
- pace
- set_number

※ Workout / WorkoutSet とはリレーションを持たせない設計

---

### 3. 種目選択フローの拡張
- 種目選択画面に「有酸素」を表示
- 有酸素選択時の遷移フロー  
```text
body_part（有酸素）
→ exercise 選択をスキップ
→ 有酸素セット入力画面
```
- 将来的な有酸素種目追加に備え、exercise 概念は残している

---

### 4. 有酸素セット入力フォームの実装
- 筋トレセット入力 UX を踏襲
- 初期表示は 1 セット
- 「＋ セットを追加」で複数セット入力可能
- 入力項目：
- 距離
- 時間
- カロリー
- ペース
- メモ

---

### 5. 保存・編集・削除処理の実装
- CardioWorkout / CardioSet をトランザクション管理で保存
- セットの一括更新・削除に対応
- 最後の有酸素セット削除時は CardioWorkout を削除
- 日付単位で筋トレ・有酸素が 0 件になった場合のみ WorkoutCleanupService が発火

---

### 6. UX（筋トレと統一）
- localDraft を利用した入力途中復元
- floating-back による「保存 or 戻る」挙動
- 編集画面では初期表示時点で draft を生成し、  
未編集・全削除・更新いずれのケースも筋トレと同様の挙動に統一

---

## 使用技術・方針
- フロントエンド：Stimulus（有酸素専用 Controller を作成）
- 既存の筋トレ実装を参考にしつつ、無理な共通化は行わない
- 将来的な拡張を前提とした最小構成

---

## Scope Out（本 PR ではやらないこと）
- カレンダー（React）への青丸表示
- 有酸素のレポート・グラフ集計
- show 画面の UI 最適化
- CardioWorkout の日付ユニーク化
- exercise_id を CardioSet 側へ移動する設計変更
- Three.js アバター成長ロジックへの影響

※ 上記は次 Issue にて対応予定

---

## 動作確認
<!-- 確認した動作や手順を記載 -->
### 記録・編集
- [x] 有酸素を選択して記録画面へ遷移できる
- [x] セットの追加・編集・削除ができる
- [x] 入力途中のリロードで内容が復元される（localDraft）
- [x] 編集画面で未編集・更新・全削除のいずれも正常に遷移する

### 削除・整合性
- [x] 有酸素セット単位で削除できる
- [x] 有酸素が残っている場合は CardioWorkout は削除されない
- [x] 最後の有酸素セット削除時に CardioWorkout が削除される
- [x] 筋トレ・有酸素が共に 0 件のときのみ Workout が削除される

### 既存機能への影響
- [x] 筋トレ記録フローに影響がない
- [x] 既存の localDraft / セット編集挙動が破綻していない

---

## 関連issue
- close #234 

---

## 補足
<!-- 注意点や次回以降の対応予定があれば記載 -->
- カレンダー表示（青丸）・React 側のリファクタは次 Issue に切り出す
- CardioWorkout の設計見直し（日付ユニーク化）は別 Issue で対応予定
