### PR TITLE
モバイル用のフッターナビの調整

### DIFF
--- a/app/javascript/styles/application.bootstrap.scss
+++ b/app/javascript/styles/application.bootstrap.scss
@@ -12,10 +12,22 @@ $flash-error-text: #9b2226;
 $flash-notice-bg: #e0e1dd;
 $flash-notice-text: #000;
 
+:root {
+  --footer-nav-height: 80px;
+}
+
 // ===== Base Layout =====
 body {
   background-color: $primary-bg;
   color: $text-light;
+}
+
+@media (max-width: 767.98px) {
+  body {
+    padding-bottom: calc(
+      var(--footer-nav-height) + env(safe-area-inset-bottom)
+    );
+  }
 }
 
 .flash-message {
@@ -143,7 +155,7 @@ body {
 
 /* ===== footer_nav（モバイル固定ナビ） ===== */
 .footer-nav {
-  height: 68px;
+  height: var(--footer-nav-height);
   padding-bottom: env(safe-area-inset-bottom);
   background: rgba(0,0,0,0.75);
   backdrop-filter: blur(8px);
@@ -153,7 +165,7 @@ body {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     gap: .25rem;
-    padding: .45rem .75rem;
+    padding: .6rem .75rem;
   }
 
   a {
@@ -163,9 +175,9 @@ body {
     flex-direction: column;
     align-items: center;
     gap: .15rem;
-    padding: .45rem .2rem;
+    padding: .6rem .25rem;
     border-radius: .75rem;
-    font-size: .65rem; // 文字小さめ
+    font-size: .7rem; // 文字小さめ
   }
 
   a[aria-current="page"],
@@ -175,7 +187,7 @@ body {
   }
 
   i[data-lucide] {
-    width: 26px;   // アイコンやや大きめ
+    width: 28px;   // アイコンやや大きめ
     height: 26px;
     stroke-width: 2.2;
   }
@@ -333,13 +345,21 @@ body {
 }
 
 @media (max-width: 767.98px) {
-  main.container.py-4 {
-    padding-bottom: calc(88px + env(safe-area-inset-bottom)) !important;
+  main.container {
+    padding-bottom: 0;
   }
 }
 
-main.container {
-  min-height: calc(100vh - 140px);
+@media (min-width: 768px) {
+  main.container {
+    min-height: calc(100vh - 140px);
+  }
+}
+
+@media (max-width: 767.98px) {
+  main.container {
+    min-height: auto;
+  }
 }
 
 /* === 種目名のカード === */


### PR DESCRIPTION
## Branch
`feature/mobile-footer-safe-area`

---

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
モバイル表示（PWA / iOS Safari）において、  
固定フッターナビゲーションがメインコンテンツや Safari の共有 UI と重なってしまう問題を解消した。

フッターナビの高さを **80px** に拡張し、  
safe-area を考慮したレイアウト調整を行うことで、  
最下部コンテンツが確実に視認・操作できる状態に改善している。

---

## 背景 / 課題
- モバイル用フッターナビ（`position: fixed`）が、
  - セット記録画面
  - 種目選択画面
  などでメインコンテンツの最下部と重なっていた
- iOS Safari では共有ボタン / ホームインジケータと Web コンテンツが干渉し、
  UI がフッターナビの下に隠れるケースが発生していた
- フッターナビのタップ領域がやや小さく、操作性改善の余地があった

---

## 実装内容
<!-- 実装した内容を箇条書きで記載 -->

### 1. モバイルフッターナビの UI 改善
- フッターナビの高さを **80px** に変更
- アイコン・テキストのタップ領域を拡張し、操作性を向上

```scss
:root {
  --footer-nav-height: 80px;
}

.footer-nav {
  height: var(--footer-nav-height);
  padding-bottom: env(safe-area-inset-bottom);
}
```

---

### 2. safe-area を考慮したスクロール領域の確保
- `body` に `padding-bottom` を付与し、
フッターナビ + iOS safe-area 分の余白を常に確保
- スクロール最下端でコンテンツがフッターナビの下に潜り込まない構成へ
変更
```scss
body {
  padding-bottom: calc(
    var(--footer-nav-height) + env(safe-area-inset-bottom)
  );
}
```

---

### 3.モバイル / PC 表示の責務分離
- モバイルのみフッターナビを表示
- PC 表示では既存のヘッダー / フッター構成を維持
- 既存画面構成への影響なし

---

## 動作確認
<!-- 確認した動作や手順を記載 -->
### モバイル（iPhone Safari / PWA 想定）
- フッターナビが常に画面下部に固定表示される
- 最下部までスクロールしてもコンテンツが隠れない
- Safari の共有ボタン / ホームインジケータと UI が干渉しない
- セット記録画面・種目選択画面でも操作可能領域が確保される
### PC (Chrome)
- フッターナビは非表示
- 既存レイアウト・スクロール挙動に変更なし

---

## 影響範囲
- UI / CSS のみ
- DB / Controller / Service への影響なし
- 既存データへの影響なし

---

## 関連issue
- close #250 

---

## 補足
<!-- 注意点や次回以降の対応予定があれば記載 -->
- フッターナビの高さを CSS 変数で管理することで、今後の微調整や画面別カスタマイズが容易な構成としている
- 今後の拡張として、
  - 入力中のフッターナビ制御
  - キーボード表示時の挙動調整
  なども検討可能