### PR TITLE
301リダイレクトを削除（cloudflareとの重複防止）

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,4 @@
 Rails.application.routes.draw do
-  constraints host: "my-training-log.com" do
-    match "*path", to: redirect { |params, request|
-      "https://torelog.app#{request.fullpath}"
-    }, via: :all, status: 301
-  end
-
   get 'three_poc/humanoid'
   devise_for :users, controllers: {
     omniauth_callbacks: "users/omniauth_callbacks"


### PR DESCRIPTION
## Branch
`feature/remove-rails-old-domain-redirect`

---

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
Cloudflare 側で `my-training-log.com → torelog.app` の 301 リダイレクトを実施しているため、
Rails 側で実装していた旧ドメイン用の redirect 制約を削除しました。

---

## 背景 / 目的
- 現在は Cloudflare で 301 リダイレクトを制御している
- Rails 側にも redirect が残っていると責務が重複する
- 二重リダイレクトや将来的な不整合を防ぐため、アプリケーション側の不要な処理を削除する

---

## 実装内容
<!-- 実装した内容を箇条書きで記載 -->
- `config/routes.rb` から旧ドメイン用の以下の制約を削除

```ruby
constraints host: "my-training-log.com" do
  match "*path", to: redirect { |params, request|
    "https://torelog.app#{request.fullpath}"
  }, via: :all, status: 301
end
```

---

## 動作確認
<!-- 確認した動作や手順を記載 -->
### ローカル
- [x] `rails routes` に `/*path redirect(301)` が表示されないことを確認
### 本番
- [x] `curl -I https://my-training-log.com` が 301 を返す（Cloudflare経由）
- [x] `server: cloudflare` になっていることを確認
- [x] `torelog.app` の主要機能（ログイン・カレンダー・API）が正常動作する

---

## 影響範囲
- 旧ドメインのリダイレクト処理は Cloudflare 側に完全移管
- Rails アプリケーションのルーティング構成を簡潔化

---

## 関連issue
- close #286 

---

## 補足
<!-- 注意点や次回以降の対応予定があれば記載 -->
- Cloudflare の 301 ルールが無効化された場合、旧ドメインが直接 Render に到達する可能性あり
- ロールバックは該当ルートを復元することで対応可能