### PR TITLE
アバター遷移先の文言を修正

### DIFF
--- a/app/views/shared/_footer_nav.html.erb
+++ b/app/views/shared/_footer_nav.html.erb
@@ -10,7 +10,7 @@
     <% end %>
     <%= link_to dashboard_avatar_path, class: "text-light #{'active' if current_page?(dashboard_avatar_path)}" do %>
       <i data-lucide="user"></i>
-      <span>プロフィール</span>
+      <span>アバター</span>
     <% end %>
     <%= link_to dashboard_setting_path, class: "text-light #{'active' if current_page?(dashboard_setting_path)}" do %>
       <i data-lucide="settings"></i>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -20,7 +20,7 @@
         <% if user_signed_in? %>
           <li class="nav-item"><%= link_to "カレンダー", dashboard_calendar_path, class: "nav-link text-light" %></li>
           <li class="nav-item"><%= link_to "レポート",   dashboard_report_path,   class: "nav-link text-light" %></li>
-          <li class="nav-item"><%= link_to "マイページ", dashboard_avatar_path,   class: "nav-link text-light" %></li>
+          <li class="nav-item"><%= link_to "アバター", dashboard_avatar_path,   class: "nav-link text-light" %></li>
           <li class="nav-item"><%= link_to "設定",       dashboard_setting_path,  class: "nav-link text-light" %></li>
         <% else %>
           <li class="nav-item"><%= link_to "ログイン",     new_user_session_path,        class: "nav-link text-light" %></li>


### PR DESCRIPTION
## Branch
`feature/rename-mypage-to-avatar`

---

## 概要
<!-- このPRで何をしたか、簡潔に記載 -->
アバター画面への遷移導線の文言が「マイページ」や「プロフィール」になっており、
遷移先の内容が直感的に分かりづらかったため、「アバター」に統一しました。

---

## 実装内容
<!-- 実装した内容を箇条書きで記載 -->
- フッターナビの遷移文言を「マイページ」→「アバター」に変更
- ナビゲーションバーの遷移文言を「プロフィール」→「アバター」に変更

---

## 変更ファイル
- app/views/shared/_footer_nav.html.erb
- app/views/shared/_navbar.html.erb

---

## 動作確認
<!-- 確認した動作や手順を記載 -->
- [x] ナビゲーションバーの表示が「アバター」になっている
- [x] フッターナビの表示が「アバター」になっている
- [x] 「アバター」からアバター表示画面へ正常に遷移できる
- [x] 他のナビゲーションに影響が出ていない

---

## 影響範囲
- ナビゲーションバー
- フッターナビ

---

## 関連issue
- close #296 

---

## 補足
<!-- 注意点や次回以降の対応予定があれば記載 -->
内部的には `profiles` という命名が残っているが、
今回の対応はユーザー視点でのUI改善を目的としているため、
影響範囲を最小限に留め、文言変更のみ実施しています。
内部命名の整理については別途対応を検討します。