### PR TITLE
セットフォームの前回値コピーのUI修正

### DIFF
--- a/app/javascript/styles/application.bootstrap.scss
+++ b/app/javascript/styles/application.bootstrap.scss
@@ -520,14 +520,9 @@ body {
 }
 
 .previous-workout-copy {
-  background: none;
-  border: none;
-  color: rgba(255,255,255,0.8);
-  font-size: 1.1rem;
-}
-
-.previous-workout-copy:hover {
-  color: #4da3ff;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .previous-workout-sets {

--- a/app/views/workouts/sets_form.html.erb
+++ b/app/views/workouts/sets_form.html.erb
@@ -31,14 +31,14 @@
       
             <button
               type="button"
-              class="previous-workout-copy"
+              class="btn btn-outline-light btn-sm previous-workout-copy"
               data-action="click->sets#copyPrevious"
               data-previous-sets="<%= h(@previous_sets.map { |s|
                 { weight: s.weight, reps: s.reps }
               }.to_json) %>"
               aria-label="前回のセットをコピー"
             >
-              ⧉
+              <i class="bi bi-arrow-repeat"></i> 前回値をコピー
             </button>
           </div>
       


### PR DESCRIPTION
## Branch
`feature/ui-set-copy`

## 概要
セット入力画面の「前回値コピー」ボタンが記号（⧉）のみでユーザーから機能の意図が分かりにくかったため、アイコン＋文言表示に変更し視認性を改善した。

## 実装内容
- `app/views/workouts/sets_form.html.erb`
  - コピー用ボタンの表示を `⧉` から Bootstrap Icons の `bi-arrow-repeat` アイコン＋「前回値をコピー」の文言に変更
  - ボタンのclassを独自クラスのみから、既存のダークカード用ボタン規約 `btn btn-outline-light btn-sm` を追加する形に変更（`shared/help/_*` 等で使われている既存パターンに統一）
  - `data-action` / `data-previous-sets` / `aria-label` は変更なし（JS挙動への影響なし）
- `app/javascript/styles/application.bootstrap.scss`
  - `.previous-workout-copy` の独自のゴーストボタンスタイル（背景なし・枠なし・hover色指定）を削除し、Bootstrapの`btn-outline-light`標準スタイルに委譲
  - アイコンと文言を横並びにするための最小限のflexスタイル（`display: inline-flex; align-items: center; gap: 4px;`）のみ残した

## 動作確認
- `sets_controller.js#copyPrevious` のロジック・データ構造に変更がないこと（ボタンクリックで前回セット値がフォームにコピーされる動作は従来通り）
- ダークカード背景上でボタンの視認性・コントラストに問題がないこと

## 補足
- 見た目とマークアップのみの変更で、JSロジックや他画面への影響はなし