### PR TITLE
3DアバターのUI/UX改善

### DIFF
--- a/app/controllers/api/avatars_controller.rb
+++ b/app/controllers/api/avatars_controller.rb
@@ -23,7 +23,7 @@ module Api
             0
           end
 
-        result[part] = Avatar::LevelThresholds.level_for(point)
+        result[part] = Avatar::LevelThresholds.progress_for(point)
       end
     end
   end

--- a/app/controllers/api/avatars_controller.rb
+++ b/app/controllers/api/avatars_controller.rb
@@ -23,7 +23,7 @@ module Api
             0
           end
 
-        result[part] = Avatar::LevelThresholds.progress_for(point)
+        result[part] = Avatar::LevelThresholds.progress_for(point, part)
       end
     end
   end

--- a/app/javascript/styles/application.bootstrap.scss
+++ b/app/javascript/styles/application.bootstrap.scss
@@ -540,6 +540,99 @@ strong {
   transform: translateY(-50%) scale(0.96);
 }
 
+/* パーツホバー/タップ時のツールチップ */
+.avatar-part-tooltip {
+  position: absolute;
+  padding: 8px 12px;
+  border-radius: 12px;
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.4;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid var(--color-border);
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 10;
+}
+
+/* ローディング/エラー表示 */
+.avatar-status {
+  position: absolute;
+  inset: 0;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  text-align: center;
+  padding: 0 16px;
+  pointer-events: none;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+}
+
+/* 部位ごとのレベル進捗バッジ */
+.avatar-level-badge {
+  position: absolute;
+  top: var(--space-4);
+  left: var(--space-4);
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  pointer-events: none;
+}
+
+.avatar-level-row {
+  display: grid;
+  grid-template-columns: 44px 40px 64px 36px;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+}
+
+.avatar-level-row__label {
+  color: var(--color-text-secondary);
+}
+
+.avatar-level-row__level {
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.avatar-level-row__bar {
+  position: relative;
+  width: 64px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--color-border);
+  overflow: hidden;
+}
+
+.avatar-level-row__bar-fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  border-radius: 999px;
+  background: var(--color-primary);
+  transition: width 0.4s ease;
+}
+
+.avatar-level-row__percent {
+  text-align: right;
+  color: var(--color-text-secondary);
+}
+
 .auth-page {
   min-height: 100vh;
   background-image: url("/auth/auth_bg_pc.jpg");

--- a/app/javascript/three/avatar/initAvatarViewer.d.ts
+++ b/app/javascript/three/avatar/initAvatarViewer.d.ts
@@ -1,7 +1,13 @@
+export type AvatarPartStat = {
+  level: string
+  progress: number
+  next_level: string | null
+}
+
 export type AvatarLevels = {
-  upper_body: string
-  core: string
-  lower_body: string
+  upper_body: AvatarPartStat
+  core: AvatarPartStat
+  lower_body: AvatarPartStat
 }
 
 export function initAvatarViewer(): Promise<void>

--- a/app/javascript/three/avatar/initAvatarViewer.js
+++ b/app/javascript/three/avatar/initAvatarViewer.js
@@ -6,6 +6,9 @@ import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment
 // パーツ切り替え時のクロスフェード演出時間(ms)
 const CROSSFADE_DURATION = 500
 
+// アバター本体に適用するブランドカラー(--color-primary系)のtint
+const AVATAR_TINT_COLOR = 0x3a86ff
+
 // Three.jsの主要オブジェクト
 let renderer = null
 let controls = null
@@ -241,6 +244,9 @@ function loadPart(part, level) {
       obj.userData.part = part
       obj.userData.level = level
 
+      // ライト/ダーク両テーマの背景に埋もれないよう、ブランドカラーでtintする
+      applyAvatarTint(obj)
+
       avatarParts[part] = obj
       scene.add(obj)
 
@@ -252,6 +258,19 @@ function loadPart(part, level) {
       setAvatarStatus("error", "一部のアバターパーツの読み込みに失敗しました。")
     }
   )
+}
+
+// オブジェクト配下のメッシュ全体をブランドカラーでtintする
+function applyAvatarTint(obj) {
+  obj.traverse((child) => {
+    if (!child.isMesh) return
+
+    const materials = Array.isArray(child.material) ? child.material : [child.material]
+    materials.forEach((mat) => {
+      if (!mat?.color) return
+      mat.color.set(AVATAR_TINT_COLOR)
+    })
+  })
 }
 
 // オブジェクト配下のメッシュ全体に不透明度を設定する
@@ -381,16 +400,15 @@ function formatPartLabel(part) {
   }
 }
 
+// 内部tier名(base/level_3/level_7)を画面表示用の1始まりレベル番号に対応させる
+const LEVEL_DISPLAY_NUMBER = { base: 1, level_3: 2, level_7: 3 }
+
 // level文字列を画面表示用の Lv.表記へ変換する
 function formatLevelLabel(level) {
   if (!level) return ""
 
-  if (level === "base") return "Lv.0"
-
-  const matched = String(level).match(/\d+/)
-  if (matched) return `Lv.${matched[0]}`
-
-  return String(level)
+  const num = LEVEL_DISPLAY_NUMBER[level]
+  return num ? `Lv.${num}` : String(level)
 }
 
 // 部位の進捗(progress: 0.0〜1.0)を画面表示用のパーセント表記へ変換する

--- a/app/javascript/three/avatar/initAvatarViewer.js
+++ b/app/javascript/three/avatar/initAvatarViewer.js
@@ -1,6 +1,10 @@
 import * as THREE from "three"
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader"
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls"
+import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment"
+
+// パーツ切り替え時のクロスフェード演出時間(ms)
+const CROSSFADE_DURATION = 500
 
 // Three.jsの主要オブジェクト
 let renderer = null
@@ -24,6 +28,13 @@ let currentHoveredPart = null
 
 // ローディング/エラー表示制御用
 let statusEl = null
+
+// レベル進捗バッジ表示制御用
+let badgeEl = null
+let badgeRowEls = {}
+
+// バッジ表示上のパーツ表示順
+const PART_ORDER = ["upper_body", "core", "lower_body"]
 
 // Turbo遷移などで確実に解除できるよう、イベントハンドラを保持する
 let handlePointerMove = null
@@ -61,10 +72,21 @@ export async function initAvatarViewer() {
   renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true })
   renderer.setSize(width, height)
   renderer.setClearColor(0x000000, 0)
+  renderer.outputColorSpace = THREE.SRGBColorSpace
+  renderer.toneMapping = THREE.ACESFilmicToneMapping
+  renderer.toneMappingExposure = 1.1
   root.appendChild(renderer.domElement)
+
+  // IBL環境光を設定し、フラットな陰影を和らげてPBRマテリアルを馴染ませる
+  const pmremGenerator = new THREE.PMREMGenerator(renderer)
+  scene.environment = pmremGenerator.fromScene(new RoomEnvironment(), 0.04).texture
+  pmremGenerator.dispose()
 
   // パーツ情報を表示するツールチップを生成する
   tooltipEl = createTooltip(root)
+
+  // レベル進捗バッジを生成する
+  badgeEl = createLevelBadge(root)
 
   // ローディング表示を生成し、取得中である旨を伝える
   statusEl = createStatus(root)
@@ -114,17 +136,21 @@ export async function initAvatarViewer() {
     fetchFailed = true
   }
 
-  // レベル未取得時は base を初期値として扱う
+  // レベル未取得時は base・進捗0を初期値として扱う
+  const fallback = { level: "base", progress: 0, next_level: "level_3" }
   avatarLevels = {
-    upper_body: levels.upper_body ?? "base",
-    core:       levels.core       ?? "base",
-    lower_body: levels.lower_body ?? "base",
+    upper_body: levels.upper_body ?? fallback,
+    core:       levels.core       ?? fallback,
+    lower_body: levels.lower_body ?? fallback,
   }
 
   // 各部位のモデルを現在レベルに応じて読み込む
-  loadPart("upper_body", avatarLevels.upper_body)
-  loadPart("core", avatarLevels.core)
-  loadPart("lower_body", avatarLevels.lower_body)
+  loadPart("upper_body", avatarLevels.upper_body.level)
+  loadPart("core", avatarLevels.core.level)
+  loadPart("lower_body", avatarLevels.lower_body.level)
+
+  // レベル進捗バッジを最新の状態に更新する
+  updateLevelBadge()
 
   // 初回は1回だけ描画（静止画）
   renderOnce()
@@ -197,16 +223,12 @@ async function fetchAvatarLevels() {
 }
 
 // 指定された部位・レベルのGLBモデルを読み込み、sceneに追加する
+// 既存モデルがある場合は即座に差し替えず、クロスフェードで滑らかに切り替える
 function loadPart(part, level) {
   if (!level) return
   const url = `/models/avatar/${part}_${level}.glb`
 
-  // 既存モデルがある場合は破棄して差し替える
-  if (avatarParts[part]) {
-    disposeObject(avatarParts[part])
-    scene.remove(avatarParts[part])
-    avatarParts[part] = null
-  }
+  const previousObj = avatarParts[part]
 
   loader.load(
     url,
@@ -222,8 +244,7 @@ function loadPart(part, level) {
       avatarParts[part] = obj
       scene.add(obj)
 
-      // モデル読み込み後に1回だけ再描画する
-      renderOnce()
+      crossfadeParts(previousObj, obj)
     },
     undefined,
     (error) => {
@@ -231,6 +252,47 @@ function loadPart(part, level) {
       setAvatarStatus("error", "一部のアバターパーツの読み込みに失敗しました。")
     }
   )
+}
+
+// オブジェクト配下のメッシュ全体に不透明度を設定する
+function setObjectOpacity(obj, opacity) {
+  obj.traverse((child) => {
+    if (!child.isMesh) return
+
+    const materials = Array.isArray(child.material) ? child.material : [child.material]
+    materials.forEach((mat) => {
+      if (!mat) return
+      mat.transparent = true
+      mat.opacity = opacity
+    })
+  })
+}
+
+// 旧モデルをフェードアウトしつつ新モデルをフェードインし、成長演出を滑らかにする
+function crossfadeParts(previousObj, nextObj, duration = CROSSFADE_DURATION) {
+  const startTime = performance.now()
+  setObjectOpacity(nextObj, 0)
+  if (previousObj) setObjectOpacity(previousObj, 1)
+
+  function step(now) {
+    const t = Math.min((now - startTime) / duration, 1)
+    setObjectOpacity(nextObj, t)
+    if (previousObj) setObjectOpacity(previousObj, 1 - t)
+
+    renderer.render(scene, camera)
+
+    if (t < 1) {
+      requestAnimationFrame(step)
+      return
+    }
+
+    if (previousObj) {
+      disposeObject(previousObj)
+      scene.remove(previousObj)
+    }
+  }
+
+  requestAnimationFrame(step)
 }
 
 // 連続描画を開始する
@@ -331,7 +393,15 @@ function formatLevelLabel(level) {
   return String(level)
 }
 
-// ツールチップDOMを生成してroot配下に追加する
+// 部位の進捗(progress: 0.0〜1.0)を画面表示用のパーセント表記へ変換する
+function formatPercentLabel(stat) {
+  if (!stat) return ""
+  if (!stat.next_level) return "MAX"
+
+  return `${Math.round((stat.progress ?? 0) * 100)}%`
+}
+
+// ツールチップDOMを生成してroot配下に追加する（配色はSCSS側のテーマ変数に委ねる）
 function createTooltip(root) {
   if (!root) return null
 
@@ -340,21 +410,7 @@ function createTooltip(root) {
 
   const el = document.createElement("div")
   el.className = "avatar-part-tooltip"
-  el.style.position = "absolute"
   el.style.display = "none"
-  el.style.pointerEvents = "none"
-  el.style.padding = "8px 12px"
-  el.style.borderRadius = "12px"
-  el.style.background = "rgba(20, 20, 24, 0.92)"
-  el.style.color = "#fff"
-  el.style.fontSize = "12px"
-  el.style.fontWeight = "600"
-  el.style.lineHeight = "1.4"
-  el.style.boxShadow = "0 8px 24px rgba(0, 0, 0, 0.28)"
-  el.style.backdropFilter = "blur(8px)"
-  el.style.webkitBackdropFilter = "blur(8px)"
-  el.style.zIndex = "10"
-  el.style.whiteSpace = "nowrap"
   el.style.transform = "translate(12px, 12px)"
 
   root.appendChild(el)
@@ -367,21 +423,64 @@ function createStatus(root) {
 
   const el = document.createElement("div")
   el.className = "avatar-status"
-  el.style.position = "absolute"
-  el.style.inset = "0"
-  el.style.display = "flex"
-  el.style.flexDirection = "column"
-  el.style.alignItems = "center"
-  el.style.justifyContent = "center"
-  el.style.gap = "8px"
-  el.style.textAlign = "center"
-  el.style.padding = "0 16px"
-  el.style.pointerEvents = "none"
-  el.style.color = "var(--color-text-secondary)"
-  el.style.fontSize = "13px"
 
   root.appendChild(el)
   return el
+}
+
+// 部位ごとのレベル進捗バッジDOMを生成してroot配下に追加する
+function createLevelBadge(root) {
+  if (!root) return null
+
+  const el = document.createElement("div")
+  el.className = "avatar-level-badge"
+
+  badgeRowEls = {}
+
+  PART_ORDER.forEach((part) => {
+    const row = document.createElement("div")
+    row.className = "avatar-level-row"
+
+    const label = document.createElement("span")
+    label.className = "avatar-level-row__label"
+    label.textContent = formatPartLabel(part)
+
+    const level = document.createElement("span")
+    level.className = "avatar-level-row__level"
+
+    const bar = document.createElement("div")
+    bar.className = "avatar-level-row__bar"
+
+    const fill = document.createElement("div")
+    fill.className = "avatar-level-row__bar-fill"
+    bar.appendChild(fill)
+
+    const percent = document.createElement("span")
+    percent.className = "avatar-level-row__percent"
+
+    row.append(label, level, bar, percent)
+    el.appendChild(row)
+
+    badgeRowEls[part] = { levelEl: level, fillEl: fill, percentEl: percent }
+  })
+
+  root.appendChild(el)
+  return el
+}
+
+// 現在のavatarLevelsを進捗バッジへ反映する
+function updateLevelBadge() {
+  if (!badgeEl) return
+
+  PART_ORDER.forEach((part) => {
+    const rowEls = badgeRowEls[part]
+    const stat = avatarLevels[part]
+    if (!rowEls || !stat) return
+
+    rowEls.levelEl.textContent = formatLevelLabel(stat.level)
+    rowEls.percentEl.textContent = formatPercentLabel(stat)
+    rowEls.fillEl.style.width = `${Math.round((stat.progress ?? 0) * 100)}%`
+  })
 }
 
 // ローディング中/エラー発生時の表示を切り替える
@@ -398,15 +497,16 @@ function setAvatarStatus(mode, message = "") {
   statusEl.textContent = message
 }
 
-// 指定部位のラベルとレベルをツールチップに表示する
+// 指定部位のラベル・レベル・進捗をツールチップに表示する
 function showTooltip(part, event) {
   if (!tooltipEl) return
 
-  const level = avatarLevels[part]
+  const stat = avatarLevels[part]
   const partLabel = formatPartLabel(part)
-  const levelLabel = formatLevelLabel(level)
+  const levelLabel = formatLevelLabel(stat?.level)
+  const percentLabel = formatPercentLabel(stat)
 
-  tooltipEl.textContent = `${partLabel} ${levelLabel}`
+  tooltipEl.textContent = `${partLabel} ${levelLabel}${percentLabel ? ` (${percentLabel})` : ""}`
   tooltipEl.style.display = "block"
 
   updateTooltipPosition(event)
@@ -480,6 +580,10 @@ export function destroyAvatarViewer() {
 
   statusEl?.remove()
   statusEl = null
+
+  badgeEl?.remove()
+  badgeEl = null
+  badgeRowEls = {}
 
   handlePointerMove = null
   handlePointerLeave = null

--- a/app/services/avatar/level_thresholds.rb
+++ b/app/services/avatar/level_thresholds.rb
@@ -1,20 +1,35 @@
 module Avatar
   class LevelThresholds
-    LEVELS = [
-      { min_point: 0,   level: "base" },
-      { min_point: 300, level: "level_3" },
-      { min_point: 700, level: "level_7" }
-    ].freeze
+    # upper_body(胸/背中/肩/腕の4カテゴリ)に対し、core(腹)/lower_body(脚)は1カテゴリしかなく
+    # 均等にトレーニングしてもpointの伸びが1/4程度になるため、閾値をカテゴリ比に合わせて調整する。
+    LEVELS_BY_PART = {
+      upper_body: [
+        { min_point: 0,   level: "base" },
+        { min_point: 300, level: "level_3" },
+        { min_point: 700, level: "level_7" }
+      ],
+      core: [
+        { min_point: 0,   level: "base" },
+        { min_point: 75,  level: "level_3" },
+        { min_point: 175, level: "level_7" }
+      ],
+      lower_body: [
+        { min_point: 0,   level: "base" },
+        { min_point: 75,  level: "level_3" },
+        { min_point: 175, level: "level_7" }
+      ]
+    }.freeze
 
-    def self.level_for(point)
-      current_level(point)[:level]
+    def self.level_for(point, avatar_part)
+      current_level(point, avatar_part)[:level]
     end
 
     # 現在tierの中で次tierまでの進捗率(0.0〜1.0)と次tier名を返す。
     # 最終tier到達時は progress: 1.0, next_level: nil を返す。
-    def self.progress_for(point)
-      current = current_level(point)
-      next_level = LEVELS[LEVELS.index(current) + 1]
+    def self.progress_for(point, avatar_part)
+      levels = LEVELS_BY_PART.fetch(avatar_part.to_sym)
+      current = current_level(point, avatar_part)
+      next_level = levels[levels.index(current) + 1]
 
       return { level: current[:level], progress: 1.0, next_level: nil } unless next_level
 
@@ -24,8 +39,8 @@ module Avatar
       { level: current[:level], progress: progress.round(2), next_level: next_level[:level] }
     end
 
-    def self.current_level(point)
-      LEVELS.reverse.find { |l| point >= l[:min_point] }
+    def self.current_level(point, avatar_part)
+      LEVELS_BY_PART.fetch(avatar_part.to_sym).reverse.find { |l| point >= l[:min_point] }
     end
     private_class_method :current_level
   end

--- a/app/services/avatar/level_thresholds.rb
+++ b/app/services/avatar/level_thresholds.rb
@@ -7,8 +7,26 @@ module Avatar
     ].freeze
 
     def self.level_for(point)
-      LEVELS
-        .reverse.find { |l| point >= l[:min_point] }[:level]
+      current_level(point)[:level]
     end
+
+    # 現在tierの中で次tierまでの進捗率(0.0〜1.0)と次tier名を返す。
+    # 最終tier到達時は progress: 1.0, next_level: nil を返す。
+    def self.progress_for(point)
+      current = current_level(point)
+      next_level = LEVELS[LEVELS.index(current) + 1]
+
+      return { level: current[:level], progress: 1.0, next_level: nil } unless next_level
+
+      span = next_level[:min_point] - current[:min_point]
+      progress = [(point - current[:min_point]).to_f / span, 1.0].min
+
+      { level: current[:level], progress: progress.round(2), next_level: next_level[:level] }
+    end
+
+    def self.current_level(point)
+      LEVELS.reverse.find { |l| point >= l[:min_point] }
+    end
+    private_class_method :current_level
   end
 end

--- a/app/services/avatar/score_increment_service.rb
+++ b/app/services/avatar/score_increment_service.rb
@@ -14,7 +14,7 @@ module Avatar
     end
 
     def level
-      Avatar::LevelThresholds.level_for(avatar_part_stat.point)
+      Avatar::LevelThresholds.level_for(avatar_part_stat.point, avatar_part_stat.avatar_part)
     end
 
     def call

--- a/spec/requests/api/avatar_spec.rb
+++ b/spec/requests/api/avatar_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe 'Api::Avatars', type: :request do
       get '/api/avatar'
 
       json = response.parsed_body
-      expect(json['upper_body']).to eq('base')
-      expect(json['core']).to eq('base')
-      expect(json['lower_body']).to eq('base')
+      expect(json['upper_body']).to eq('level' => 'base', 'progress' => 0.0, 'next_level' => 'level_3')
+      expect(json['core']).to eq('level' => 'base', 'progress' => 0.0, 'next_level' => 'level_3')
+      expect(json['lower_body']).to eq('level' => 'base', 'progress' => 0.0, 'next_level' => 'level_3')
     end
 
-    it 'stat が存在する場合は level を反映する' do
+    it 'stat が存在する場合は level と進捗率を反映する' do
       user.avatar_part_stats.create!(
         avatar_part: :upper_body,
         point: 300,
@@ -39,7 +39,7 @@ RSpec.describe 'Api::Avatars', type: :request do
       get '/api/avatar'
       json = response.parsed_body
 
-      expect(json['upper_body']).to eq('level_3')
+      expect(json['upper_body']).to eq('level' => 'level_3', 'progress' => 0.0, 'next_level' => 'level_7')
     end
   end
 end

--- a/spec/requests/api/avatar_spec.rb
+++ b/spec/requests/api/avatar_spec.rb
@@ -41,5 +41,18 @@ RSpec.describe 'Api::Avatars', type: :request do
 
       expect(json['upper_body']).to eq('level' => 'level_3', 'progress' => 0.0, 'next_level' => 'level_7')
     end
+
+    it 'core は upper_body より低い point(75)で level_3 に到達する' do
+      user.avatar_part_stats.create!(
+        avatar_part: :core,
+        point: 75,
+        last_trained_at: Time.current
+      )
+
+      get '/api/avatar'
+      json = response.parsed_body
+
+      expect(json['core']).to eq('level' => 'level_3', 'progress' => 0.0, 'next_level' => 'level_7')
+    end
   end
 end

--- a/spec/services/avatar/level_thresholds_spec.rb
+++ b/spec/services/avatar/level_thresholds_spec.rb
@@ -10,4 +10,19 @@ RSpec.describe Avatar::LevelThresholds do
       expect(described_class.level_for(700)).to eq('level_7')
     end
   end
+
+  describe '.progress_for' do
+    it '現在tier内での進捗率と次tier名を返す' do
+      expect(described_class.progress_for(0)).to eq(level: 'base', progress: 0.0, next_level: 'level_3')
+      expect(described_class.progress_for(150)).to eq(level: 'base', progress: 0.5, next_level: 'level_3')
+      expect(described_class.progress_for(299)).to eq(level: 'base', progress: 1.0, next_level: 'level_3')
+      expect(described_class.progress_for(300)).to eq(level: 'level_3', progress: 0.0, next_level: 'level_7')
+      expect(described_class.progress_for(500)).to eq(level: 'level_3', progress: 0.5, next_level: 'level_7')
+    end
+
+    it '最終tier到達時は progress: 1.0, next_level: nil を返す' do
+      expect(described_class.progress_for(700)).to eq(level: 'level_7', progress: 1.0, next_level: nil)
+      expect(described_class.progress_for(10_000)).to eq(level: 'level_7', progress: 1.0, next_level: nil)
+    end
+  end
 end

--- a/spec/services/avatar/level_thresholds_spec.rb
+++ b/spec/services/avatar/level_thresholds_spec.rb
@@ -2,27 +2,45 @@ require 'rails_helper'
 
 RSpec.describe Avatar::LevelThresholds do
   describe '.level_for' do
-    it 'point に応じた level を返す' do
-      expect(described_class.level_for(0)).to eq('base')
-      expect(described_class.level_for(299)).to eq('base')
-      expect(described_class.level_for(300)).to eq('level_3')
-      expect(described_class.level_for(699)).to eq('level_3')
-      expect(described_class.level_for(700)).to eq('level_7')
+    it 'upper_body は point に応じた level を返す(閾値 300/700)' do
+      expect(described_class.level_for(0, :upper_body)).to eq('base')
+      expect(described_class.level_for(299, :upper_body)).to eq('base')
+      expect(described_class.level_for(300, :upper_body)).to eq('level_3')
+      expect(described_class.level_for(699, :upper_body)).to eq('level_3')
+      expect(described_class.level_for(700, :upper_body)).to eq('level_7')
+    end
+
+    it 'core / lower_body は point に応じた level を返す(閾値 75/175)' do
+      %i[core lower_body].each do |part|
+        expect(described_class.level_for(0, part)).to eq('base')
+        expect(described_class.level_for(74, part)).to eq('base')
+        expect(described_class.level_for(75, part)).to eq('level_3')
+        expect(described_class.level_for(174, part)).to eq('level_3')
+        expect(described_class.level_for(175, part)).to eq('level_7')
+      end
     end
   end
 
   describe '.progress_for' do
-    it '現在tier内での進捗率と次tier名を返す' do
-      expect(described_class.progress_for(0)).to eq(level: 'base', progress: 0.0, next_level: 'level_3')
-      expect(described_class.progress_for(150)).to eq(level: 'base', progress: 0.5, next_level: 'level_3')
-      expect(described_class.progress_for(299)).to eq(level: 'base', progress: 1.0, next_level: 'level_3')
-      expect(described_class.progress_for(300)).to eq(level: 'level_3', progress: 0.0, next_level: 'level_7')
-      expect(described_class.progress_for(500)).to eq(level: 'level_3', progress: 0.5, next_level: 'level_7')
+    it 'upper_body の現在tier内での進捗率と次tier名を返す' do
+      expect(described_class.progress_for(0, :upper_body)).to eq(level: 'base', progress: 0.0, next_level: 'level_3')
+      expect(described_class.progress_for(150, :upper_body)).to eq(level: 'base', progress: 0.5, next_level: 'level_3')
+      expect(described_class.progress_for(299, :upper_body)).to eq(level: 'base', progress: 1.0, next_level: 'level_3')
+      expect(described_class.progress_for(300, :upper_body)).to eq(level: 'level_3', progress: 0.0, next_level: 'level_7')
+      expect(described_class.progress_for(500, :upper_body)).to eq(level: 'level_3', progress: 0.5, next_level: 'level_7')
+    end
+
+    it 'core の現在tier内での進捗率と次tier名を返す(閾値 75/175)' do
+      expect(described_class.progress_for(0, :core)).to eq(level: 'base', progress: 0.0, next_level: 'level_3')
+      expect(described_class.progress_for(37, :core)).to eq(level: 'base', progress: 0.49, next_level: 'level_3')
+      expect(described_class.progress_for(75, :core)).to eq(level: 'level_3', progress: 0.0, next_level: 'level_7')
+      expect(described_class.progress_for(125, :core)).to eq(level: 'level_3', progress: 0.5, next_level: 'level_7')
     end
 
     it '最終tier到達時は progress: 1.0, next_level: nil を返す' do
-      expect(described_class.progress_for(700)).to eq(level: 'level_7', progress: 1.0, next_level: nil)
-      expect(described_class.progress_for(10_000)).to eq(level: 'level_7', progress: 1.0, next_level: nil)
+      expect(described_class.progress_for(700, :upper_body)).to eq(level: 'level_7', progress: 1.0, next_level: nil)
+      expect(described_class.progress_for(10_000, :upper_body)).to eq(level: 'level_7', progress: 1.0, next_level: nil)
+      expect(described_class.progress_for(175, :lower_body)).to eq(level: 'level_7', progress: 1.0, next_level: nil)
     end
   end
 end


### PR DESCRIPTION
## ブランチ名

`feature/avatar-ui-modernize`（ベース: `main`）

## 概要

トレーニング記録に応じて成長する3Dアバター機能のUI/UXを改善する。
- three.js標準機能のみで見た目をモダン化し、レベル進捗を体感しやすくする
- ライトテーマでアバターが背景に埋もれて見えにくい問題を解消する
- レベル表記をユーザーにとって直感的な1始まり表記に変更する
- 部位（上半身/コア/下半身）ごとのトレーニング種目数の差により生じていたスコアの伸びやすさの不公平を是正する

新規npmパッケージ・Blenderでのアセット再制作は行わず、既存の3段階GLB（base/level_3/level_7）とインストール済みの`three`のみで実現した。DBスキーマ変更なし。

## 実装内容

**見た目のモダン化**
- `renderer.outputColorSpace` / `toneMapping`（ACESFilmic）を設定し、PBRマテリアルの陰影を改善
- `RoomEnvironment` + `PMREMGenerator`によるIBL環境光を追加
- レベル切替時に旧モデル→新モデルをクロスフェード（約500ms）させ、唐突なポップインを解消
- アバター本体にブランドカラー（`#3a86ff`系）のtintを適用し、ライト/ダーク両テーマで背景に埋もれず視認できるように改善

**レベル進捗の可視化**
- `Avatar::LevelThresholds#progress_for`を追加し、現在tier内の進捗率(0.0〜1.0)・次tier名をバックエンドで算出
- `/api/avatar`のレスポンスを`level`文字列から`{ level, progress, next_level }`のオブジェクト形式に変更
- 部位ごとの進捗バー付きレベルバッジUI、ツールチップの進捗%表示を追加
- レベル表記を内部tier名の数字そのまま（Lv.0/3/7、MAXがLv.7）から、ユーザー向けに1始まり3段階（Lv.1/2/3、MAXがLv.3）の表示に変更（表示層のみの変更で、内部tier名・GLBファイル名は維持）

**部位間のスコア格差是正**
- `BODY_PART_TO_AVATAR_PART`で上半身は胸/背中/肩/腕の4カテゴリ、コア（腹）・下半身（脚）は各1カテゴリしかなく、均等にトレーニングしてもコア/下半身のpointが伸びにくい問題があった
- `Avatar::LevelThresholds`を`avatar_part`別の閾値（`LEVELS_BY_PART`）に変更し、コア/下半身の閾値をカテゴリ比（4:1）に合わせて上半身の1/4（75/175）に引き下げ。point加算ロジック（+1/セット）自体は変更せず、pointの意味は全部位で統一したまま是正

**テーマ整合**
- ツールチップ/ステータス表示のインラインハードコード配色をやめ、`var(--color-*)`を参照するCSSクラスに置き換え、ダーク/ライト両テーマに対応

## 実装ファイル（新規・既存）

新規作成ファイルはなし。すべて既存ファイルの変更。

**既存ファイル**
- `app/services/avatar/level_thresholds.rb` — `avatar_part`別閾値化、`progress_for`追加
- `app/controllers/api/avatars_controller.rb` — レスポンス形式変更、`progress_for`呼び出しに`avatar_part`を追加
- `app/services/avatar/score_increment_service.rb` — `level`呼び出しに`avatar_part`を追加
- `app/javascript/three/avatar/initAvatarViewer.js` — 描画モダン化、クロスフェード演出、進捗バッジUI、ブランドカラーtint、レベル表記リナンバリング
- `app/javascript/three/avatar/initAvatarViewer.d.ts` — 型定義更新
- `app/javascript/styles/application.bootstrap.scss` — 進捗バッジ/ツールチップ/ステータスのテーマ対応スタイル追加
- `spec/requests/api/avatar_spec.rb` — レスポンス形式変更・閾値差分のテスト追加
- `spec/services/avatar/level_thresholds_spec.rb` — 新シグネチャ・新閾値のテスト追加

## 動作確認

Docker Compose（`db`, `app`）でアプリを起動し、Playwrightで検証用テストユーザー（確認後DBから削除済み）を用いて実ブラウザで確認。

- `/dashboard/avatar`にログイン後アクセスし、3Dアバター・部位別進捗バッジ（例: 上半身Lv.1 50%、体幹Lv.1 53%、下半身Lv.3 MAX）が正しく表示されることを確認
- モデルへのホバーでツールチップに部位名・レベル・進捗%が表示されることを確認
- `point`が閾値（upper_body: 300、core/lower_body: 75）を跨ぐようにデータを更新し、レベル切替時のクロスフェード演出とバッジ更新を確認
- ダーク/ライト両テーマで表示を確認し、ブランドカラーでtintしたアバターが両テーマとも背景に埋もれず視認できること、ツールチップ/バッジの配色が破綻しないことを確認
- ブラウザのコンソールエラーがないことを確認

## テスト結果

Docker経由（ローカルにruby-3.2.2未インストールのため）で実行、全て成功。

```rspec
$ bundle exec rspec spec/services/avatar/level_thresholds_spec.rb 

spec/requests/api/avatar_spec.rb 

spec/services/avatar/score_increment_services_spec.rb

12 examples, 0 failures
```

- `npm run build` / `npm run build:css` ともにビルドエラーなし

## 補足

- DBスキーマ変更なし（`avatar_part_stats.point`から都度計算する既存方式を維持）
- `/api/avatar`のレスポンス形式が文字列からオブジェクトに変わったが、内部APIでありフロント（`initAvatarViewer.js`）・テストとも本PR内で追随済み
- 3Dモデル自体の連続的な体形変化（モーフターゲット等によるなめらかな変形）は今回未実装。既存GLBがボーン/シェイプキーを持たない静的メッシュのため、真の粒度向上にはBlenderでのモーフターゲット/リグ作成が別途必要（今回はUI/演出面での体感向上に留めている）
- PoC実装（`humanoid_poc.js`等）、未使用の`AvatarPart.tsx`など本改修と無関係なファイルは変更していない
